### PR TITLE
Utilisation de la nouvelle commande Scalingo `backups-download` au lieu de `backup-command`

### DIFF
--- a/steps.js
+++ b/steps.js
@@ -62,7 +62,7 @@ function getBackupId({ addonId }) {
 
 function downloadBackup({ addonId, backupId }) {
   const compressedBackup = 'backup.tar.gz';
-  execSync('scalingo', [ '--addon', addonId, 'backup-download', '--silent', '--backup', backupId, '-o', compressedBackup ]);
+  execSync('scalingo', [ '--addon', addonId, 'backups-download', '--silent', '--backup', backupId, '--output', compressedBackup ]);
 
   if (!fs.existsSync('backup.tar.gz')) {
     throw new Error('Backup download failed');


### PR DESCRIPTION
La commande `backup-download` est obsolète et remplacée par `backups-download` : https://github.com/Scalingo/cli/pull/452

En principe l'ancienne commande `backup-download` devrait toujours fonctionner avec un warning, mais elle ne reconnaît aucun flag : https://github.com/Scalingo/cli/pull/452/files#diff-6eae5f17654b235c68ab2bb17d69c9f2L32