### PR TITLE
[BUGFIX] Correction de la typo sur logger.

### DIFF
--- a/steps.js
+++ b/steps.js
@@ -159,7 +159,7 @@ async function fullReplicationAndEnrichment() {
 
   await addEnrichment();
 
-  loger.info('Full replication and enrichment done');
+  logger.info('Full replication and enrichment done');
 }
 
 module.exports = {


### PR DESCRIPTION
Le fichier steps.js contient une erreur `loger` au lieu de `logger`.

Corriger en expedit.

Un deuxième ticket va corriger toutes les erreurs soulevées par le linter.