### PR TITLE
[BUGFIX] Une fonction qui n'existe pas est exportée dans le module.exports

### DIFF
--- a/steps.js
+++ b/steps.js
@@ -187,7 +187,6 @@ function _filterObjectLines(objectLines) {
 
 module.exports = {
   addEnrichment,
-  createRestoreList,
   downloadAndRestoreLatestBackup,
   downloadBackup,
   dropCurrentObjects,


### PR DESCRIPTION
Dans le fichier `step.js`, une fonction `createRestoreList` était exportée. Or celle-ci n'existe pas.

Je n'ai pas encore bien compris pourquoi, mais ça ne pose pas de problèmes au job de réplication.
Par contre, lorsqu'on lance via node run.js, là ça ne marche pas.