### PR TITLE
Mise à jour de la version par défaut du client psql (10=>12)

### DIFF
--- a/steps.js
+++ b/steps.js
@@ -4,7 +4,7 @@
 // https://www.npmjs.com/package/dotenv#usage
 require('dotenv').config();
 
-const PG_CLIENT_VERSION = process.env.PG_CLIENT_VERSION || '10.4';
+const PG_CLIENT_VERSION = process.env.PG_CLIENT_VERSION || '12';
 const PG_RESTORE_JOBS = parseInt(process.env.PG_RESTORE_JOBS, 10) || 4;
 const MAX_RETRY_COUNT = parseInt(process.env.MAX_RETRY_COUNT, 10) || 10;
 const RETRIES_TIMEOUT_MINUTES = parseInt(process.env.RETRIES_TIMEOUT_MINUTES, 10) || 180;


### PR DESCRIPTION
Tous les environnements étant en version 12, passage de la version par défaut en v12 
(configuration active en production = 12 - `PG_CLIENT_VERSION=12`)