### PR TITLE
[BUGFIX] Remplacer la fonction dépréciée dans execa shellsync 

### DIFF
--- a/steps.js
+++ b/steps.js
@@ -20,7 +20,7 @@ const logger = require('./logger');
 const RESTORE_LIST_FILENAME = 'restore.list';
 
 function shellSync(cmdline) {
-  execa.shellSync(cmdline, { stdio: 'inherit' });
+  execa.shell(cmdline, { stdio: 'inherit' });
 }
 
 function execSync(cmd, args) {


### PR DESCRIPTION
## :unicorn: Problème
La fonction `shellSync` a été remplacée par `shell` lors de la [v2](https://github.com/sindresorhus/execa/releases/tag/v2.0.0)

## :robot: Solution
Utiliser `shell`

## :100: Pour tester
Testé 
- en [local](https://github.com/1024pix/pix-db-replication/blob/master/README.md#int%C3%A9gration)
- en [distant](https://github.com/1024pix/pix-db-replication/blob/master/README.md#manuels-sur-scalingo)
