### PR TITLE
[BUGFIX] Restaurer la fonction execa shellSync

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -15,7 +15,7 @@
 
 DATABASE_URL=postgresql://postgres@localhost/pix-db-replication
 
-PG_CLIENT_VERSION = '10.4';
+PG_CLIENT_VERSION = '12';
 PG_RESTORE_JOBS = 4;
 MAX_RETRY_COUNT = 10;
 RETRIES_TIMEOUT_MINUTES = 180;

--- a/steps.js
+++ b/steps.js
@@ -20,7 +20,7 @@ const logger = require('./logger');
 const RESTORE_LIST_FILENAME = 'restore.list';
 
 function shellSync(cmdline) {
-  execa.shell(cmdline, { stdio: 'inherit' });
+  execa.shellSync(cmdline, { stdio: 'inherit' });
 }
 
 function execSync(cmd, args) {


### PR DESCRIPTION
## :unicorn: Problème
Annulation de la [PR](https://github.com/1024pix/pix-db-replication/pull/31) qui n'a pas résolu le problème

## :robot: Solution
Restauration de `shellSync` au lie de `shell`

## :100: Pour tester
Testé sur application `osc-fr1/pix-db-replication` après déploiement sur master => OK
```
2020-10-17 21:42:12.794061359 +0200 CEST [one-off-3234] pg_restore: creating FK CONSTRAINT "public.campaign-participations campaign_participations_campaignid_foreign"
2020-10-17 21:42:12.775558235 +0200 CEST [one-off-3234] pg_restore: creating FK CONSTRAINT "public.badges badges_targetprofileid_foreign"
2020-10-17 21:42:12.772148192 +0200 CEST [one-off-3234] pg_restore: creating FK CONSTRAINT "public.badge-partner-competences badge_partner_competences_badgeid_foreign"
2020-10-17 21:42:12.832729709 +0200 CEST [one-off-3234] pg_restore: creating FK CONSTRAINT "public.certification-candidates certification_candidates_userid_foreign"
2020-10-17 21:42:12.829556752 +0200 CEST [one-off-3234] pg_restore: creating FK CONSTRAINT "public.certification-candidates certification_candidates_sessionid_foreign"
```
