### PR TITLE
Ajouter le nom de l'application Scalingo dans les logs

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -1,7 +1,9 @@
 const bunyan = require('bunyan');
+const repositoryName = 'pix-db-replication';
+const loggedApplicationName = process.env.APP || repositoryName;
 
 const logger = bunyan.createLogger({
-  name: 'pix-db-replication',
+  name: loggedApplicationName,
   stream: process.stdout,
   level: 'info'
 });


### PR DESCRIPTION
## :unicorn: Problème
Il y a 3 applications Scalingo utilisant le repository `pix-db-replication`

Peu importe l'application Scalingo, le logger mentionne `pix-db-replication`

`2020-10-20 04:44:54.369057243 +0200 CEST [background-1] {"name":"pix-db-replication","hostname":"pix-db-replication-fork-background-1","pid":19,"level":30,"msg":"Full replication and enrichment done","time":"2020-10-20T02:44:54.368Z","v":0}`

## :robot: Solution
Récupérer le nom de l'application Scalingo via [les variables d'environnement](https://doc.scalingo.com/platform/app/environment#runtime-environment-variables)
La passer au logger

## :100: Pour tester
Consulter les logs de la RA et vérifier qu'elles mentionnent  `pix-datawarehouse-pr39`

`2020-10-26 08:39:30.221656138 +0100 CET [one-off-1778] {"name":"pix-datawarehouse-pr39","hostname":"pix-datawarehouse-pr39-one-off-1778","pid":23,"level":30,"msg":"Restore done","time":"2020-10-26T07:39:30.221Z","v":0}`
