### PR TITLE
Passer le dépôt de code en visibilité publique

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pix-db-replication",
   "version": "1.0.0",
-  "private": true,
+  "private": false,
   "description": "Socle d'application décisionnelle: import données par backup/copie à chaud/API et enrichissement ",
   "license": "AGPL-3.0",
   "author": "GIP Pix",


### PR DESCRIPTION
## :unicorn: Problème

Le repository satisfait IMHO tous les critères évoquées par @jbuget pour être rendu public
 - du code qui ne contienne aucune variable d’environnement en clair
- du code qui ne contienne aucune données perso (en particulier des auteurs, sauf peut-être pour des infos de core maintainers)
- du code couvert par des tests
- du code dont on a envie d’être fier (on peut ouvrir du code cra-cra si on ambitionne de le rendre propre un jour)
- du code dont en pense qu’il peut avoir une vraie plus-value pour d’autres SE / services publics / projets OSS ou privés

## :robot: Solution
Relire le code disponible, et si c'est OK, merger la PR puis changer la visibilité GitHub

## :100: Pour tester
Stratégie de test manuel et automatique: voir README.md
Test en RA OK
```
scalingo run --region osc-fr1 -a pix-datawarehouse-pr56 --size M --detached node run.js  
{"name":"pix-datawarehouse-pr56","hostname":"pix-datawarehouse-pr56-one-off-3618","pid":23,"level":30,"msg":"Full replication and enrichment done","time":"2020-11-16T07:37:34.967Z","v":0}
```