### PR TITLE
[TECH] Conversion des appels synchrones en appels asynchrones

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -329,6 +329,15 @@
         "type-detect": "^4.0.5"
       }
     },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "^1.0.2"
+      }
+    },
     "chalk": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "eslint": "^7.11.0",
     "eslint-plugin-mocha": "^8.0.0",
     "eslint-plugin-node": "^11.1.0",

--- a/replication_job.js
+++ b/replication_job.js
@@ -9,14 +9,20 @@ const parisTimezone = 'Europe/Paris';
 const extractConfigurationFromEnvironment = require ('./src/extract-configuration-from-environment');
 const configuration = extractConfigurationFromEnvironment();
 
-steps.scalingoSetup(configuration);
+async function main() {
+  await steps.scalingoSetup(configuration);
+  new CronJob(configuration.SCHEDULE, async function() {
+    try {
+      await steps.fullReplicationAndEnrichment(configuration);
+    } catch (error) {
+      logger.error(error);
+      process.exit(1);
+    }
+  }, null, true, parisTimezone);
+}
 
-new CronJob(configuration.SCHEDULE, async function() {
-  try {
-    await steps.fullReplicationAndEnrichment(configuration);
-  } catch (error) {
+main()
+  .catch((error) => {
     logger.error(error);
     process.exit(1);
-  }
-}, null, true, parisTimezone);
-
+  });

--- a/replication_job.js
+++ b/replication_job.js
@@ -26,3 +26,13 @@ main()
     logger.error(error);
     process.exit(1);
   });
+
+function exitOnSignal(signal) {
+  logger.info(`Received signal ${signal}.`);
+  process.exit(1);
+}
+
+process.on('uncaughtException', () => { exitOnSignal('uncaughtException'); });
+process.on('unhandledRejection', () => { exitOnSignal('unhandledRejection'); });
+process.on('SIGTERM', () => { exitOnSignal('SIGTERM'); });
+process.on('SIGINT', () => { exitOnSignal('SIGINT'); });

--- a/run.js
+++ b/run.js
@@ -20,3 +20,12 @@ main()
     process.exit(1);
   });
 
+function exitOnSignal(signal) {
+  logger.info(`Received signal ${signal}.`);
+  process.exit(1);
+}
+
+process.on('uncaughtException', () => { exitOnSignal('uncaughtException'); });
+process.on('unhandledRejection', () => { exitOnSignal('unhandledRejection'); });
+process.on('SIGTERM', () => { exitOnSignal('SIGTERM'); });
+process.on('SIGINT', () => { exitOnSignal('SIGINT'); });

--- a/run.js
+++ b/run.js
@@ -6,9 +6,12 @@ const steps = require('./steps');
 const extractConfigurationFromEnvironment = require ('./src/extract-configuration-from-environment');
 const configuration = extractConfigurationFromEnvironment();
 
-steps.scalingoSetup(configuration);
+async function main() {
+  await steps.scalingoSetup(configuration);
+  return steps.fullReplicationAndEnrichment(configuration);
+}
 
-steps.fullReplicationAndEnrichment(configuration)
+main()
   .then(() => {
     process.exit(0);
   })

--- a/steps.js
+++ b/steps.js
@@ -17,8 +17,8 @@ function execShell(cmdline) {
   return execa(cmdline, { stdio: 'inherit', shell: true });
 }
 
-function execSync(cmd, args) {
-  execa.sync(cmd, args, { stdio: 'inherit' });
+function exec(cmd, args) {
+  return execa(cmd, args, { stdio: 'inherit' });
 }
 
 function execSyncStdOut(cmd, args) {
@@ -71,18 +71,18 @@ async function setupPath() {
 }
 
 function installPostgresClient(configuration) {
-  execSync('dbclient-fetcher', [ 'pgsql', configuration.PG_CLIENT_VERSION ]);
+  return exec('dbclient-fetcher', [ 'pgsql', configuration.PG_CLIENT_VERSION ]);
 }
 
 async function scalingoSetup(configuration) {
   await setupPath();
-  installPostgresClient(configuration);
+  return installPostgresClient(configuration);
 }
 
-function extractBackup({ compressedBackup }) {
-  // MACOS: execSync('tar', [ 'xvzf', compressedBackup ]);
+async function extractBackup({ compressedBackup }) {
+  // MACOS: exec('tar', [ 'xvzf', compressedBackup ]);
   logger.info('Start Extract backup');
-  execSync('tar', [ 'xvzf', compressedBackup, '--wildcards', '*.pgsql']);
+  await exec('tar', [ 'xvzf', compressedBackup, '--wildcards', '*.pgsql']);
   const backupFile = fs.readdirSync('.').find((f) => /.*\.pgsql$/.test(f));
   if (!backupFile) {
     throw new Error(`Could not find .pgsql file in ${compressedBackup}`);
@@ -93,14 +93,14 @@ function extractBackup({ compressedBackup }) {
 
 function dropCurrentObjects(configuration) {
   // TODO: pass DATABASE_URL by argument
-  execSync('psql', [ configuration.DATABASE_URL, ' --echo-all', '--set', 'ON_ERROR_STOP=on', '--command', 'DROP OWNED BY CURRENT_USER CASCADE' ]);
+  return exec('psql', [ configuration.DATABASE_URL, ' --echo-all', '--set', 'ON_ERROR_STOP=on', '--command', 'DROP OWNED BY CURRENT_USER CASCADE' ]);
 }
 
-function dropCurrentObjectsButKesAndAnswers(configuration) {
+async function dropCurrentObjectsButKesAndAnswers(configuration) {
   const dropTableQuery = execSyncStdOut('psql', [ configuration.DATABASE_URL, '--tuples-only', '--command', 'select string_agg(\'drop table "\' || tablename || \'" CASCADE\', \'; \') from pg_tables where schemaname = \'public\' and tablename not in (\'knowledge-elements\', \'answers\');' ]);
   const dropFunction = execSyncStdOut('psql', [ configuration.DATABASE_URL, '--tuples-only', '--command', 'select string_agg(\'drop function "\' || proname || \'"\', \'; \') FROM pg_proc pp INNER JOIN pg_roles pr ON pp.proowner = pr.oid WHERE pr.rolname = current_user ' ]);
-  execSync('psql', [ configuration.DATABASE_URL, '--set', 'ON_ERROR_STOP=on', '--echo-all' , '--command', dropTableQuery ]);
-  execSync('psql', [ configuration.DATABASE_URL, '--set', 'ON_ERROR_STOP=on', '--echo-all' , '--command', dropFunction ]);
+  await exec('psql', [ configuration.DATABASE_URL, '--set', 'ON_ERROR_STOP=on', '--echo-all' , '--command', dropTableQuery ]);
+  return exec('psql', [ configuration.DATABASE_URL, '--set', 'ON_ERROR_STOP=on', '--echo-all' , '--command', dropFunction ]);
 }
 
 function writeListFileForReplication({ backupFile, configuration }) {
@@ -110,13 +110,13 @@ function writeListFileForReplication({ backupFile, configuration }) {
   fs.writeFileSync(RESTORE_LIST_FILENAME, filteredObjectLines.join('\n'));
 }
 
-function restoreBackup({ backupFile, databaseUrl, configuration }) {
+async function restoreBackup({ backupFile, databaseUrl, configuration }) {
   logger.info('Start restore');
 
   try {
     writeListFileForReplication({ backupFile, configuration });
     // TODO: pass DATABASE_URL by argument
-    execSync('pg_restore', [
+    await exec('pg_restore', [
       '--verbose',
       '--jobs', configuration.PG_RESTORE_JOBS,
       '--no-owner',
@@ -156,17 +156,17 @@ async function getScalingoBackup() {
   return extractBackup({ compressedBackup });
 }
 
-function dropObjectAndRestoreBackup(backupFile, configuration) {
+async function dropObjectAndRestoreBackup(backupFile, configuration) {
   logger.info('Start drop Objects AndRestoreBackup');
   if (configuration.RESTORE_ANSWERS_AND_KES_INCREMENTALLY && configuration.RESTORE_ANSWERS_AND_KES_INCREMENTALLY === 'true') {
-    dropCurrentObjectsButKesAndAnswers(configuration);
+    await dropCurrentObjectsButKesAndAnswers(configuration);
   } else {
-    dropCurrentObjects(configuration);
+    await dropCurrentObjects(configuration);
   }
   logger.info('End drop Objects AndRestoreBackup');
 
   logger.info('Start restore Backup');
-  restoreBackup({ backupFile, databaseUrl: configuration.DATABASE_URL, configuration });
+  await restoreBackup({ backupFile, databaseUrl: configuration.DATABASE_URL, configuration });
   logger.info('End restore Backup');
 }
 

--- a/steps.js
+++ b/steps.js
@@ -13,8 +13,8 @@ const logger = require('./logger');
 
 const RESTORE_LIST_FILENAME = 'restore.list';
 
-function shellSync(cmdline) {
-  execa.sync(cmdline, { stdio: 'inherit', shell: true });
+function execShell(cmdline) {
+  return execa(cmdline, { stdio: 'inherit', shell: true });
 }
 
 function execSync(cmd, args) {
@@ -64,8 +64,8 @@ function retryFunctionAirTable(fn, maxRetryCount) {
 }
 
 // dbclient-fetch assumes $HOME/bin is in the PATH
-function setupPath() {
-  shellSync('mkdir -p "$HOME/bin"');
+async function setupPath() {
+  await execShell('mkdir -p "$HOME/bin"');
   // eslint-disable-next-line no-process-env
   process.env.PATH = process.env.HOME + '/bin' + ':' + process.env.PATH;
 }
@@ -74,8 +74,8 @@ function installPostgresClient(configuration) {
   execSync('dbclient-fetcher', [ 'pgsql', configuration.PG_CLIENT_VERSION ]);
 }
 
-function scalingoSetup(configuration) {
-  setupPath();
+async function scalingoSetup(configuration) {
+  await setupPath();
   installPostgresClient(configuration);
 }
 
@@ -138,7 +138,7 @@ async function getScalingoBackup() {
     token: process.env.SCALINGO_API_TOKEN,
     region: process.env.SCALINGO_REGION,
   });
-    
+
   const addon = await client.getAddon('postgresql');
   logger.info('Add-on ID: ' + addon.id);
 
@@ -170,7 +170,7 @@ function dropObjectAndRestoreBackup(backupFile, configuration) {
   logger.info('End restore Backup');
 }
 
-async function  importAirtableData(configuration) {
+async function importAirtableData(configuration) {
 
   const wrappedCall = async function() {
     try {

--- a/test/integration/steps_test.js
+++ b/test/integration/steps_test.js
@@ -39,10 +39,11 @@ describe('Integration | steps.js', () => {
         const configuration = { RESTORE_FK_CONSTRAINTS: 'false', PG_RESTORE_JOBS: 4 };
 
         // when
-        steps.restoreBackup({ backupFile, databaseUrl: databaseConfig.databaseUrl, configuration });
+        await steps.restoreBackup({ backupFile, databaseUrl: databaseConfig.databaseUrl, configuration });
 
         // then
-        const restoredRowCount = parseInt(await database.runSql(`SELECT COUNT(*) FROM ${databaseConfig.tableName}`));
+        const countOfTable = await database.runSql(`SELECT COUNT(*) FROM ${databaseConfig.tableName}`);
+        const restoredRowCount = parseInt(countOfTable);
         expect(restoredRowCount).to.equal(databaseConfig.tableRowCount);
 
         // then


### PR DESCRIPTION
## :unicorn: Problème
Beaucoup d'appels sont effectués de façon synchrone. C'est une stratégie pertinente lorsque l'appel en question est court. Autrement, cela peut poser des problèmes variés (notamment de performance). En effet, les appels synchrones "verrouillent" les ressources du process et les rendent indisponibles.
Avec la facilité d'écriture des appels asynchrones (async/await), il n'y a plus d'excuses !!

## :robot: Solution
Remplacement de execa.sync -> execa.
+ Ajout d'un handler de signaux système type SIGTERM

## :rainbow: Remarques

## :100: Pour tester
Tester la non régression pour la transfo sync -> async
Pour tester la gestion des signaux système : scale down le container background, constater l'apparition du log correspondant dans les logs (en effet, le scale down envoie un SIGTERM au container)
