### PR TITLE
[DOC] Corriger la documentation concernant l'exécution locale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 restore.list
 backup.tar.gz
 logs.txt
+
+# OS - MacOSX
+.DS_Store

--- a/sample.env
+++ b/sample.env
@@ -157,10 +157,11 @@ TARGET_DATABASE_URL=
 # URL d'accès à la base _cible_ qui sera écrasée et alimentée depuis le
 # _backup_ à chaque exécution. Cette variable est en principe automatiquement
 # alimentée par Scalingo lors de l'ajout d'une base PostgreSQL.
+# L'utilisateur ne doit PAS etre postgres !
 #
 # presence: required
 # type: DatabaseURL
-# default: none
+# default: postgresql://pix@localhost/replication_target
 DATABASE_URL=
 
 

--- a/steps.js
+++ b/steps.js
@@ -277,4 +277,5 @@ module.exports = {
   restoreBackup,
   retryFunction,
   scalingoSetup,
+  addEnrichment
 };

--- a/test/utils/create-user.js
+++ b/test/utils/create-user.js
@@ -1,0 +1,14 @@
+const extractConfigurationFromEnvironment = require ('../../src/extract-configuration-from-environment');
+const configuration = extractConfigurationFromEnvironment();
+const Database = require('../utils/database');
+const pgUrlParser = require('pg-connection-string').parse;
+
+const parsedConnectionString = pgUrlParser(configuration.DATABASE_URL);
+
+const databaseConfig = {
+  serverUrl: `postgres://${parsedConnectionString.user}@${parsedConnectionString.host}:${parsedConnectionString.port}`,
+  databaseName: parsedConnectionString.database
+};
+
+const database = new Database(databaseConfig.serverUrl, databaseConfig.databaseName);
+return database.createUser();

--- a/test/utils/database.js
+++ b/test/utils/database.js
@@ -1,6 +1,8 @@
 const execa = require('execa');
 const tmp = require('tmp-promise');
 const pgUrlParser = require('pg-connection-string').parse;
+const superUser = 'postgres';
+const databaseProtocol = 'postgres';
 
 module.exports = class Database {
 
@@ -10,7 +12,7 @@ module.exports = class Database {
     this._databaseUrl = `${this._serverUrl}/${this._databaseName}`;
     const config = pgUrlParser(this._databaseUrl);
     this._user = config.user;
-    this._superUserServerUrl = `postgres://postgres@${config.host}:${config.port}`;
+    this._superUserServerUrl = `${databaseProtocol}://${superUser}@${config.host}:${config.port}`;
     this._superUserDatabaseUrl = `${this._superUserServerUrl}/${config.database}`;
   }
 


### PR DESCRIPTION
## :unicorn: Problème
Scalingo restaure la base sur un utilisateur non privilégié.
L'outil utilisé en local,` docker-compose`, nepermet pas sa création

## :robot: Solution
Fournir un script de création d'utiliusateur

## :rainbow: Remarques
On réutilisera la classe utilitaire Database pour garantir le cohérence avec les tests

## :100: Pour tester
Voir README.md
