### PR TITLE
[FEATURE] Utiliser la Scalingo API pour télécharger le backup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -239,6 +239,14 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "axios": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.0.tgz",
+      "integrity": "sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -1115,6 +1123,11 @@
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1367,6 +1380,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -2123,6 +2141,47 @@
       "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
       "optional": true
     },
+    "scalingo": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/scalingo/-/scalingo-0.2.2.tgz",
+      "integrity": "sha512-K3jMED18x41Em8dud7kCbWPzzVowPjQInUhmBgQqz/FiBuMwqOcrICucrbL8CCZ2XXRoP6SOstkUBZA3lsy2BQ==",
+      "requires": {
+        "axios": "0.19.x",
+        "isomorphic-ws": "4.x",
+        "ws": "7.x"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.19.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+          "requires": {
+            "follow-redirects": "1.5.10"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "semver": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
@@ -2539,6 +2598,11 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
+    },
+    "ws": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
+      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "main": "replication_job.js",
   "dependencies": {
     "airtable": "^0.10.0",
+    "axios": "^0.21.0",
     "bunyan": "^1.8.14",
     "check-engine": "^1.9.0",
     "cron": "^1.8.2",
@@ -35,7 +36,8 @@
     "moment": "^2.29.1",
     "p-retry": "4.2.0",
     "pg": "^8.4.1",
-    "pg-format": "^1.0.4"
+    "pg-format": "^1.0.4",
+    "scalingo": "^0.2.2"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/sample.env
+++ b/sample.env
@@ -63,7 +63,7 @@ AIRTABLE_API_KEY=
 # default: none
 AIRTABLE_BASE=
 
-# Cette variable est utilisée automatiquement par l'outil CLI de Scalingo, et
+# Cette variable est utilisée automatiquement par l'API de Scalingo, et
 # doit contenir le nom de l'application portant la base de données _source_
 # (`pix-api-production` typiquement).
 #
@@ -72,7 +72,7 @@ AIRTABLE_BASE=
 # default: none
 SCALINGO_APP=
 
-# cette variable est utilisée automatiquement par l'outil CLI de Scalingo pour
+# cette variable est utilisée automatiquement par l'API de Scalingo pour
 # l'authentification, et doit être renseignée avec un _token_ d'utilisateur
 # Scalingo étant collaborateur de l'application désignée par `SCALINGO_APP`.
 #
@@ -80,6 +80,15 @@ SCALINGO_APP=
 # type: String
 # default: none
 SCALINGO_API_TOKEN=
+
+# Region Scalingo utilisée pour générer les URLs d'APIs Scalingo:
+# Scalingo API: https://api.[SCALINGO_REGION].scalingo.com
+# Database API: https://db-api.[SCALINGO_REGION].scalingo.com
+# 
+# presence: required
+# type: String
+# default: none
+SCALINGO_REGION=
 
 # Une chaîne au format `cron` (interprétée par
 # https://www.npmjs.com/package/node-cron) qui spécifie la fréquence à

--- a/src/scalingo/client.js
+++ b/src/scalingo/client.js
@@ -1,0 +1,42 @@
+const scalingo = require('scalingo');
+const ScalingoDBClient = require('./db-client');
+
+class ScalingoClient {
+  constructor(client, app, region) {
+    this.app = app;
+    this.client = client;
+    this.region = region;
+  }
+
+  static async getInstance({ app, token, region }) {
+    const apiUrl = `https://api.${region}.scalingo.com`;
+    const client = await scalingo.clientFromToken(token, { apiUrl });
+
+    return new ScalingoClient(client, app, region);
+  }
+
+  async getAddon(addonProviderId) {
+    try {
+      const addons = await this.client.Addons.for(this.app);
+      return addons.find((addon) => addon.addon_provider.id === addonProviderId);
+    } catch (e) {
+      throw new Error(`Unable to get the addon "${addonProviderId}" with Scalingo API.`);
+    }
+  }
+
+  async getAddonApiToken(addonId) {
+    try {
+      const response = await this.client.apiClient().post(`/apps/${this.app}/addons/${addonId}/token`);
+      return response.data.addon.token;
+    } catch (e) {
+      throw new Error('Unable to get the addon token with Scalingo API.');
+    }
+  }
+
+  async getDatabaseClient(dbId) {
+    const dbToken = await this.getAddonApiToken(dbId);
+    return ScalingoDBClient.getInstance({ dbId, dbToken, region: this.region });
+  }
+}
+
+module.exports = ScalingoClient;

--- a/src/scalingo/db-client.js
+++ b/src/scalingo/db-client.js
@@ -1,0 +1,53 @@
+const axios = require('axios');
+const util = require('util');
+const fs = require('fs');
+const streamPipeline = util.promisify(require('stream').pipeline);
+
+class ScalingoDBClient {
+  constructor(dbId, client) {
+    this.dbId = dbId;
+    this.client = client;
+  }
+
+  static getInstance({ dbId, dbToken, region }) {
+    const client = axios.create({
+      baseURL: `https://db-api.${region}.scalingo.com/api`,
+      headers: { Authorization: `Bearer ${dbToken}` },
+    });
+
+    return new ScalingoDBClient(dbId, client);
+  }
+
+  async getBackups() {
+    try {
+      const response = await this.client.get(`/databases/${this.dbId}/backups`);
+      return response.data.database_backups;
+    } catch (e) {
+      throw new Error('Unable to get the backup with Scalingo Database API.');
+    }
+  }
+
+  async getBackupDownloadLink(backupId) {
+    try {
+      const response = await this.client.get(`/databases/${this.dbId}/backups/${backupId}/archive`);
+      return response.data.download_url;
+    } catch (e) {
+      throw new Error('Unable to get the backup download link with Scalingo Database API.');
+    }
+  }
+
+  async downloadBackup(backupId, output) {
+    const downloadUrl = await this.getBackupDownloadLink(backupId);
+
+    let downloadResponse;
+    try {
+      downloadResponse = await axios.get(downloadUrl, { responseType: 'stream' });
+    } catch (e) {
+      throw new Error('Unable to download the backup.');
+    }
+
+    await streamPipeline(downloadResponse.data, fs.createWriteStream(output));
+  }
+}
+
+module.exports = ScalingoDBClient;

--- a/src/scalingo/utils.js
+++ b/src/scalingo/utils.js
@@ -1,0 +1,17 @@
+const moment = require('moment');
+
+function getTodayBackup(backups) {
+  const today = moment();
+  const found = backups.filter((backup) => {
+    return today.isSame(backup.created_at, 'day') && backup.status === 'done';
+  });
+
+  if (found.length === 0) {
+    throw new Error('The backup for today is not available.');
+  }
+  return found[0];
+}
+
+module.exports = {
+  getTodayBackup,
+};

--- a/test/unit/scalingo/client_test.js
+++ b/test/unit/scalingo/client_test.js
@@ -1,0 +1,143 @@
+const sinon = require('sinon');
+const scalingo = require('scalingo');
+const { expect } = require('chai');
+
+const ScalingoClient = require('../../../src/scalingo/client');
+const ScalingoDBClient = require('../../../src/scalingo/db-client');
+
+const SCALINGO_APP = 'SCALINGO_APP';
+const SCALINGO_API_TOKEN = 'SCALINGO_API_TOKEN';
+const SCALINGO_REGION = 'SCALINGO_REGION';
+const SCALINGO_API_URL = `https://api.${SCALINGO_REGION}.scalingo.com`;
+
+describe('Client wrapper for Scalingo API', () => {
+  const clientParameters = {
+    app: SCALINGO_APP,
+    token: SCALINGO_API_TOKEN,
+    region: SCALINGO_REGION,
+  };
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('#ScalingoClient.getInstance', () => {
+    it('should return the Scalingo client instance', async () => {
+      // given
+      sinon.stub(scalingo, 'clientFromToken').resolves({ apiClient: () => {} });
+      // when
+      const scalingoClient = await ScalingoClient.getInstance(clientParameters);
+      // then
+      sinon.assert.calledWithExactly(scalingo.clientFromToken, SCALINGO_API_TOKEN, {
+        apiUrl: SCALINGO_API_URL,
+      });
+      expect(scalingoClient).to.be.an.instanceof(ScalingoClient);
+      expect(scalingoClient.client).to.exist;
+    });
+
+    it('should throw an error when scalingo authentication failed', async () => {
+      // given
+      sinon.stub(scalingo, 'clientFromToken').rejects(new Error('Invalid credentials'));
+      // when
+      let scalingoClient;
+      try {
+        scalingoClient = await ScalingoClient.getInstance(clientParameters);
+        expect.fail('should raise an error when credentials are invalid');
+      } catch (e) {
+        expect(scalingoClient).to.be.undefined;
+      }
+    });
+  });
+
+  describe('#ScalingoClient.getAddon', () => {
+    const addonsStub = { for: () => {} };
+    let scalingoClient;
+
+    beforeEach(async () => {
+      sinon.stub(scalingo, 'clientFromToken').resolves({ Addons: addonsStub });
+      scalingoClient = await ScalingoClient.getInstance(clientParameters);
+    });
+
+    it('should return the postgresql addon if found', async () => {
+      // given
+      sinon.stub(addonsStub, 'for').resolves([{ addon_provider: { id: 'postgresql' } }]);
+      // when
+      const result = await scalingoClient.getAddon('postgresql');
+      // then
+      sinon.assert.calledWithExactly(addonsStub.for, SCALINGO_APP);
+      expect(result).to.be.deep.equal({ addon_provider: { id: 'postgresql' } });
+    });
+
+    it('should return undefined if addon not found', async () => {
+      // given
+      sinon.stub(addonsStub, 'for').resolves([{ addon_provider: { id: 'redis' } }]);
+      // when
+      const result = await scalingoClient.getAddon('postgresql');
+      // then
+      expect(result).to.be.undefined;
+    });
+
+    it('should throw an error when scalingo api failed', async () => {
+      // given
+      sinon.stub(addonsStub, 'for').rejects(new Error('Invalid credentials'));
+      // when
+      try {
+        await scalingoClient.getAddon('postgresql');
+        expect.fail('should raise an error when Scalingo API failed');
+      } catch (e) {
+        expect(e.message).to.equal('Unable to get the addon "postgresql" with Scalingo API.');
+      }
+    });
+  });
+
+  describe('#ScalingoClient.getAddonApiToken', () => {
+    const apiClientStub = { get: () => {}, post: () => {} };
+    let scalingoClient;
+
+    beforeEach(async () => {
+      sinon.stub(scalingo, 'clientFromToken').resolves({ apiClient: () => apiClientStub });
+      scalingoClient = await ScalingoClient.getInstance(clientParameters);
+    });
+
+    it('should return the postgresql addon if found', async () => {
+      // given
+      sinon.stub(apiClientStub, 'post').resolves({ data: { addon: { token: 'token1' } } });
+      // when
+      const result = await scalingoClient.getAddonApiToken(1);
+      // then
+      sinon.assert.calledWithExactly(apiClientStub.post, `/apps/${SCALINGO_APP}/addons/1/token`);
+      expect(result).to.be.equal('token1');
+    });
+
+    it('should throw an error when scalingo api failed', async () => {
+      // given
+      sinon.stub(apiClientStub, 'get').rejects(new Error('Invalid credentials'));
+      // when
+      try {
+        await scalingoClient.getAddonApiToken(1);
+        expect.fail('should raise an error when Scalingo API failed');
+      } catch (e) {
+        expect(e.message).to.equal('Unable to get the addon token with Scalingo API.');
+      }
+    });
+  });
+
+  describe('#ScalingoClient.getDatabaseClient', () => {
+    const apiClientStub = { post: () => {} };
+    let scalingoClient;
+
+    beforeEach(async () => {
+      sinon.stub(scalingo, 'clientFromToken').resolves({ apiClient: () => apiClientStub });
+      scalingoClient = await ScalingoClient.getInstance(clientParameters);
+    });
+
+    it('should return the database API client', async () => {
+      // given
+      sinon.stub(apiClientStub, 'post').resolves({ data: { addon: { token: 'token1' } } });
+      // when
+      const result = await scalingoClient.getDatabaseClient('dbId1');
+      // then
+      expect(result).to.be.an.instanceof(ScalingoDBClient);
+    });
+  });
+});

--- a/test/unit/scalingo/db-client_test.js
+++ b/test/unit/scalingo/db-client_test.js
@@ -1,0 +1,89 @@
+const nock = require('nock');
+const { expect } = require('chai');
+
+const ScalingoDBClient = require('../../../src/scalingo/db-client');
+
+const SCALINGO_REGION = 'SCALINGO_REGION';
+const SCALINGO_DB_API_URL = `https://db-api.${SCALINGO_REGION}.scalingo.com`;
+
+describe('Client wrapper for Scalingo Database API', () => {
+  let client;
+  const dbId = 'dbId1';
+
+  beforeEach(() => {
+    nock.cleanAll();
+    nock.disableNetConnect();
+  
+    client = ScalingoDBClient.getInstance({
+      dbId,
+      dbToken: 'dbToken1',
+      region: SCALINGO_REGION,
+    });
+  });
+
+  describe('#ScalingoDBClient.getInstance', () => {
+    it('should return the Scalingo client instance', async () => {
+      expect(client).to.be.an.instanceof(ScalingoDBClient);
+      expect(client.client).to.exist;
+    });
+  });
+
+  describe('#ScalingoDBClient.getBackups', () => {
+    it('should return the list of backups for the given addon', async () => {
+      // given
+      const backups = {
+        database_backups: [
+          {
+            id: 'backup1',
+            created_at: '2020-11-10T23:00:00.473+01:00',
+            started_at: '2020-11-10T23:01:09.834+01:00',
+            status: 'done',
+          },
+        ],
+      };
+      nock(SCALINGO_DB_API_URL).get(`/api/databases/${dbId}/backups`).reply(200, backups);
+      // when
+      const result = await client.getBackups();
+      // then
+      expect(result).to.be.deep.equal(backups.database_backups);
+    });
+
+    it('should throw an error if Scalingo database API call fails', async () => {
+      // given
+      nock(SCALINGO_DB_API_URL).get(`/api/databases/${dbId}/backups`).reply(503);
+      // when
+      try {
+        await client.getBackups();
+        expect.fail('should raise an error when backup for today not found');
+      } catch (e) {
+        expect(e.message).to.equal('Unable to get the backup with Scalingo Database API.');
+      }
+    });
+  });
+
+  describe('#ScalingoDBClient.getBackupDownloadLink', () => {
+    const backupId = 'backupId';
+
+    it('should return the backup download link for the given addon backup', async () => {
+      // given
+      const response = { download_url: 'https://domain.com/backup.tar.gz' };
+      nock(SCALINGO_DB_API_URL).get(`/api/databases/${dbId}/backups/${backupId}/archive`).reply(200, response);
+      // when
+      const result = await client.getBackupDownloadLink(backupId);
+      // then
+      expect(result).to.be.deep.equal(response.download_url);
+    });
+
+    it('should throw an error if Scalingo database API call fails', async () => {
+      // given
+      nock(SCALINGO_DB_API_URL).get(`/api/databases/${dbId}/backups/${backupId}/archive`).reply(503);
+      // when
+      try {
+        await client.getBackupDownloadLink(backupId);
+        expect.fail('should raise an error when api call failed');
+      } catch (e) {
+        expect(e.message).to.equal('Unable to get the backup download link with Scalingo Database API.');
+      }
+    });
+  });
+});

--- a/test/unit/scalingo/utils_test.js
+++ b/test/unit/scalingo/utils_test.js
@@ -1,0 +1,70 @@
+const sinon = require('sinon');
+const { expect } = require('chai');
+
+const { getTodayBackup } = require('../../../src/scalingo/utils');
+
+describe('Scalingo utils', () => {
+  describe('getTodayBackup', () => {
+    beforeEach(async () => {
+      sinon.useFakeTimers(new Date(2020, 10, 10));
+    });
+
+    afterEach(async () => {
+      sinon.restore();
+    });
+
+    it('should return the todays backup for the given addon', async () => {
+      // given
+      const backups = [
+        {
+          id: 'backup1',
+          created_at: '2020-11-10T23:00:00.473+01:00',
+          started_at: '2020-11-10T23:01:09.834+01:00',
+          status: 'done',
+        },
+      ];
+      // when
+      const result = getTodayBackup(backups);
+      // then
+      expect(result.id).to.be.deep.equal('backup1');
+    });
+
+    it('should throw an error if backup for today not found', async () => {
+      // given
+      const backups = [
+        {
+          id: 'backup1',
+          created_at: '2020-11-09T23:00:00.473+01:00',
+          started_at: '2020-11-09T23:01:09.834+01:00',
+          status: 'done',
+        },
+      ];
+      // when
+      try {
+        getTodayBackup(backups);
+        expect.fail('should raise an error when backup for today not found');
+      } catch (e) {
+        expect(e.message).to.equal('The backup for today is not available.');
+      }
+    });
+
+    it('should throw an error if backup for today is not finished', async () => {
+      // given
+      const backups = [
+        {
+          id: 'backup1',
+          created_at: '2020-11-10T23:00:00.473+01:00',
+          started_at: '2020-11-10T23:01:09.834+01:00',
+          status: 'pending',
+        },
+      ];
+      // when
+      try {
+        getTodayBackup(backups);
+        expect.fail('should raise an error when backup for today not found');
+      } catch (e) {
+        expect(e.message).to.equal('The backup for today is not available.');
+      }
+    });
+  });
+});

--- a/test/unit/steps_test.js
+++ b/test/unit/steps_test.js
@@ -1,7 +1,6 @@
 const { expect } = require('chai');
-const moment = require('moment');
 
-const { retryFunction, _getBackupIdForDate } = require('../../steps');
+const { retryFunction } = require('../../steps');
 
 function catchErr(promiseFn, ctx) {
   return async (...args) => {
@@ -71,40 +70,6 @@ describe('Unit | steps.js', () => {
       // then
       expect(error).to.be.instanceOf(Error);
       expect(nbRetries).to.be.equal(expectedNbRetries);
-    });
-  });
-
-  describe('#_getBackupIdForYesterday', () => {
-
-    it('should return backup from yesterday when done', async function() {
-      // given
-      const nov25 = '2020-11-25T08:56:16.553Z';
-      const backups = `| today-but-not-done | Mon, 25 Nov 2020 01:00:00 CET | 25 GB  | WIP   |
-| backup-from-incorrect-day | Mon, 24 Nov 2020 01:00:00 CET | 25 GB  | done   |
-| correct-backupId | Mon, 25 Nov 2020 01:00:00 CET | 25 GB  | done   |`;
-      const date = moment(nov25).format('D MMM Y');
-
-      // when
-      const result = _getBackupIdForDate(backups, date);
-
-      // then
-      expect(result).to.deep.equal({ 'backupId': 'correct-backupId' });
-    });
-
-    it('should throw an error when backup is not ready or available', async function() {
-      // given
-      const dateWithoutBackup = '2020-11-27T08:56:16.553Z';
-      const backups = `| today-but-not-done | Mon, 25 Nov 2020 01:00:00 CET | 25 GB  | WIP   |
-| backup-from-incorrect-day | Mon, 24 Nov 2020 01:00:00 CET | 25 GB  | done   |
-| correct-backupId | Mon, 25 Nov 2020 01:00:00 CET | 25 GB  | done   |`;
-      const date = moment(dateWithoutBackup).format('D MMM Y');
-
-      // when
-      const error = await catchErr(_getBackupIdForDate)(backups, date);
-
-      // then
-      expect(error).to.be.instanceOf(Error);
-      expect(error.message).to.equal('The backup for yesterday is not available');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, la réplication utilise le CLI de Scalingo qui est difficilement testable et utilisable dans un process node.

## :robot: Solution

Utiliser l'API de scalingo et `scalingo.js` pour effectuer les opérations actuelles du CLI.

Les opérations effectuées avec le CLI sont :
- Récupération de l'id de l'addon
- Récupération de l'id du backup du jour (terminé)
- Téléchargement du backup

Toutes ces opérations ont des équivalents dans l'API Scalingo et la Database API de Scalingo:
- [Récupération de l'id de l'addon](https://developers.scalingo.com/addons#list-application-addons)
- [Récupération de l'id du backup du jour (terminé)](https://developers.scalingo.com/databases/backups#list-database-backups)
- [Récupération du lien de téléchargement du backup](https://developers.scalingo.com/databases/backups#get-a-backup-download-link)

## :rainbow: Remarques

N/A

## :100: Pour tester

- Les tests des appels API (`ScalingoClient` et `ScalingoDbClient`) ont été automatisés via des tests unitaires.
- Des tests d'intégration manuels sur la RA sont nécessaires pour une validation complète.
