### PR TITLE
Ne pas restaurer les snapshot de KE pour les internes

### DIFF
--- a/steps.js
+++ b/steps.js
@@ -128,6 +128,8 @@ async function createBackup(configuration) {
     ? []
     : [
       '--exclude-table', 'knowledge-elements',
+      '--exclude-table', 'knowledge-element-snapshots',
+      '--exclude-table', 'knowledge-element-snapshots_id_seq',
       '--exclude-table', 'answers',
     ];
   const verboseOptions = process.env.NODE_ENV === 'test' ? [] : ['--verbose'];

--- a/test/integration/test-helper.js
+++ b/test/integration/test-helper.js
@@ -49,7 +49,9 @@ async function createTablesThatMayNotBeRestored(database) {
   await database.runSql('CREATE TABLE answers (id int NOT NULL PRIMARY KEY, "challengeId" CHARACTER VARYING(255) )');
   await database.runSql('INSERT INTO answers (id, "challengeId") VALUES (1,2)');
   await database.runSql('CREATE TABLE "knowledge-elements" (id int NOT NULL PRIMARY KEY, "userId" INTEGER, "createdAt" TIMESTAMP WITH TIME ZONE)');
-  await database.runSql('INSERT INTO "knowledge-elements"  (id, "userId", "createdAt") VALUES (1, 2, CURRENT_TIMESTAMP)');
+  await database.runSql('CREATE TABLE "knowledge-element-snapshots" (id serial)');
+  await database.runSql('INSERT INTO "knowledge-elements" (id, "userId", "createdAt") VALUES (1, 2, CURRENT_TIMESTAMP)');
+  await database.runSql('INSERT INTO "knowledge-element-snapshots" DEFAULT VALUES');
   await database.runSql('CREATE INDEX "knowledge_elements_userid_index" ON "knowledge-elements" ("userId")');
 }
 

--- a/test/unit/steps_test.js
+++ b/test/unit/steps_test.js
@@ -79,6 +79,7 @@ describe('Unit | steps.js', () => {
   });
 
   describe('#createBackup', () => {
+
     let execStub;
     let createBackup;
 
@@ -121,7 +122,8 @@ describe('Unit | steps.js', () => {
       expect(backupFilename).to.equal('./dump.pgsql');
     });
 
-    context('when anwers and knowledge elements are restored incrementally', () => {
+    context('when answers and knowledge elements are restored incrementally', () => {
+
       it('should not backup answers and knowledge-elements tables', async () => {
         // given
         const configuration = {
@@ -148,14 +150,15 @@ describe('Unit | steps.js', () => {
             '--exclude-schema', '\'^pg_*\'',
             '--file', './dump.pgsql',
             '--exclude-table', 'knowledge-elements',
-            '--exclude-table', 'answers'
+            '--exclude-table', 'knowledge-element-snapshots',
+            '--exclude-table', 'knowledge-element-snapshots_id_seq',
+            '--exclude-table', 'answers',
+
           ],
           { stdio: 'inherit' }
         );
-
       });
     });
-
   });
 
 });


### PR DESCRIPTION
## :unicorn: Problème
La table `knowledge-element-snapshots` est volumineuse, ce qui ralenti la création du dump, et donc la mise à disposition des données, alors qu'elle n'est pas utilisée par les internes

## :robot: Solution
Exclure la table `knowledge-element-snapshots`  du dump

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
