### PR TITLE
Permettre la relance de l'enrichissement

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ Checking versions...
 ### Paramétrage
 Créer un fichier `.env` à partir du fichier [sample.env](sample.env)
 
+### Import AirTable
+``` bash
+node -e "steps=require('./steps'); steps.importAirtableData(require ('./src/extract-configuration-from-environment')())"
+```
+
+### Enrichissement
+Création index, vues..
+``` bash
+node -e "steps=require('./steps'); steps.addEnrichment(require ('./src/extract-configuration-from-environment')())"
+```
+
 ### Réplication complète
 Elle débute par la création d'un backup de la base de données source.
 Elle ne peut pas être exécutée en local (utilisation du binaire `dbclient-fetcher` disponible uniquement sur Scalingo ).

--- a/steps.js
+++ b/steps.js
@@ -220,18 +220,19 @@ async function backupAndRestore(configuration) {
 }
 
 async function fullReplicationAndEnrichment(configuration) {
-  logger.info('Start replication and enrichment');
 
-  logger.info('Create and restore backup');
+  logger.info('Start import and enrichment');
+
+  logger.info('Import data from API database');
   await backupAndRestore(configuration);
 
-  logger.info('Retrieve AirTable data to database ');
+  logger.info('Import data from AirTable');
   await importAirtableData(configuration);
 
-  logger.info('Enrich');
+  logger.info('Enrich imported data');
   await addEnrichment(configuration);
 
-  logger.info('Full replication and enrichment done');
+  logger.info('Import and enrichment done');
 
 }
 

--- a/steps.js
+++ b/steps.js
@@ -254,12 +254,13 @@ function _filterObjectLines(objectLines, configuration) {
 }
 
 module.exports = {
+  addEnrichment,
   backupAndRestore,
+  createBackup,
   dropObjectAndRestoreBackup,
   fullReplicationAndEnrichment,
   importAirtableData,
-  restoreBackup,
-  retryFunction,
   pgclientSetup,
-  createBackup,
+  restoreBackup,
+  retryFunction
 };


### PR DESCRIPTION
## :unicorn: Problème
Si l'import AirTable sort en erreur, une fois corrigé, il n'est pas possible de lancer la dernière étape, l'enrichissement. 
Cela oblige à relancer tout le traitement (création + import du dump) alors que les données sont là.

## :robot: Solution
Exposer la fonction concernée

## :100: Pour tester
Voir l'ajout effectué dans README.md
