### PR TITLE
[TECH] Mettre à jour l'image docker de postgresql utilisée par la CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
   test:
     docker:
       - image: cimg/node:14.15.4
-      - image: postgres:12-alpine
+      - image: postgres:12.4-alpine
         environment:
           POSTGRES_USER: postgres
           POSTGRES_HOST_AUTH_METHOD: trust


### PR DESCRIPTION
## :unicorn: Problème
L'image de Postgresql utilisée par la CI n'est pas en cohérence avec celle utilisée dans le `docker-compose`.

## :robot: Solution
Passer de la version `postgres:12-alpine`  à `postgres:12.4-alpine`.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
