### PR TITLE
Ajouter des tests d'acceptance

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -52,7 +52,7 @@ RETRIES_TIMEOUT_MINUTES=
 #
 # presence: required
 # type: String
-# default: none
+# default: keyblo10ZCvCqBAJg
 AIRTABLE_API_KEY=
 
 # API token provided in your Airtable database configuration used for fetching
@@ -60,7 +60,7 @@ AIRTABLE_API_KEY=
 #
 # presence: required
 # type: String
-# default: none
+# default: app3fvsqhtHJntXaC
 AIRTABLE_BASE=
 
 # Une chaîne au format `cron` (interprétée par

--- a/test/acceptance/full-dump-replication.js
+++ b/test/acceptance/full-dump-replication.js
@@ -1,0 +1,156 @@
+const { expect } = require('chai');
+const { createAndFillDatabase } = require('../integration/test-helper');
+const Database = require('../utils/database');
+const pgUrlParser = require('pg-connection-string').parse;
+
+const steps = require('../../src/steps');
+
+async function getCountFromTable({ targetDatabase, tableName }) {
+  return parseInt(await targetDatabase.runSql(`SELECT COUNT(*) FROM ${tableName}`));
+}
+
+describe('Acceptance | steps | fullReplicationAndEnrichment', () => {
+
+  // CircleCI set up environment variables to access DB, so we need to read them here
+  // eslint-disable-next-line no-process-env
+  const SOURCE_DATABASE_URL = process.env.SOURCE_DATABASE_URL || 'postgres://pix@localhost:5432/replication_source';
+  // eslint-disable-next-line no-process-env
+  const TARGET_DATABASE_URL = process.env.TARGET_DATABASE_URL || 'postgres://pix@localhost:5432/replication_target';
+
+  let sourceDatabase;
+  let targetDatabase;
+  let sourceDatabaseConfig;
+  let targetDatabaseConfig;
+
+  before(async function() {
+    this.timeout(5000);
+
+    const rawSourceDataBaseConfig = pgUrlParser(SOURCE_DATABASE_URL);
+
+    sourceDatabaseConfig = {
+      serverUrl: `postgres://${rawSourceDataBaseConfig.user}@${rawSourceDataBaseConfig.host}:${rawSourceDataBaseConfig.port}`,
+      databaseName: rawSourceDataBaseConfig.database,
+      tableName: 'test_table',
+      tableRowCount: 100000,
+    };
+
+    sourceDatabaseConfig.databaseUrl = `${sourceDatabaseConfig.serverUrl}/${sourceDatabaseConfig.databaseName}`;
+
+    const rawTargetDataBaseConfig = pgUrlParser(TARGET_DATABASE_URL);
+
+    targetDatabaseConfig = {
+      serverUrl: `postgres://${rawSourceDataBaseConfig.user}@${rawTargetDataBaseConfig.host}:${rawTargetDataBaseConfig.port}`,
+      databaseName: rawTargetDataBaseConfig.database,
+      tableName: 'test_table',
+      tableRowCount: 100000,
+    };
+
+    targetDatabaseConfig.databaseUrl = `${targetDatabaseConfig.serverUrl}/${targetDatabaseConfig.databaseName}`;
+
+    // given
+    const configuration = {
+      SOURCE_DATABASE_URL,
+      TARGET_DATABASE_URL,
+      DATABASE_URL: TARGET_DATABASE_URL,
+      RESTORE_ANSWERS_AND_KES: 'true',
+      PG_RESTORE_JOBS: 1,
+      AIRTABLE_API_KEY: 'keyblo10ZCvCqBAJg',
+      AIRTABLE_BASE: 'app3fvsqhtHJntXaC'
+    };
+    sourceDatabase = await Database.create(sourceDatabaseConfig);
+    await createAndFillDatabase(sourceDatabase, sourceDatabaseConfig, { createTablesNotToBeImported: true });
+    targetDatabase = await Database.create(targetDatabaseConfig);
+
+    // when
+    await steps.fullReplicationAndEnrichment(configuration);
+  });
+
+  after(async () => {
+    await sourceDatabase.dropDatabase();
+    await targetDatabase.dropDatabase();
+  });
+
+  describe('should import database data', () => {
+
+    it('should replicate answers and knowledge-elements ', async () => {
+      // then
+      const restoredRowCount = await getCountFromTable({ targetDatabase, tableName: targetDatabaseConfig.tableName });
+
+      expect(restoredRowCount).to.equal(targetDatabaseConfig.tableRowCount);
+
+      const isAnswersRestored = parseInt(await targetDatabase.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'answers\''));
+      expect(isAnswersRestored).to.equal(1);
+
+      // then
+      const isKnowledgeElementsRestored = parseInt(await targetDatabase.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-elements\''));
+      expect(isKnowledgeElementsRestored).to.equal(1);
+
+      const indexCount = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'users_createdAt_idx\''));
+      expect(indexCount).to.equal(1);
+    });
+  });
+
+  describe('should import Airtable data', () => {
+
+    it('should import areas ', async () => {
+      // then
+      const result = await getCountFromTable({ targetDatabase, tableName: 'areas' });
+      expect(result).to.be.above(0);
+    });
+
+    it('should import competences ', async () => {
+      // then
+      const result = await getCountFromTable({ targetDatabase, tableName: 'competences' });
+      expect(result).to.be.above(0);
+    });
+
+    it('should import tubes ', async () => {
+      // then
+      const result = await getCountFromTable({ targetDatabase, tableName: 'tubes' });
+      expect(result).to.be.above(0);
+    });
+
+    it('should import skills ', async () => {
+      // then
+      const result = await getCountFromTable({ targetDatabase, tableName: 'skills' });
+      expect(result).to.be.above(0);
+    });
+
+    it('should import challenges ', async () => {
+      // then
+      const result = await getCountFromTable({ targetDatabase, tableName: 'challenges' });
+      expect(result).to.be.above(0);
+    });
+
+    it('should import tutorials ', async () => {
+      // then
+      const result = await getCountFromTable({ targetDatabase, tableName: 'tutorials' });
+      expect(result).to.be.above(0);
+    });
+  });
+
+  describe ('should enrich imported data', () => {
+
+    it('should create indexes', async function() {
+      // then
+      const indexCount = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'users_createdAt_idx\''));
+      expect(indexCount).to.equal(1);
+
+      // then
+      const KEIndexCount = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'knowledge-elements_createdAt_idx\''));
+      expect(KEIndexCount).to.equal(1);
+
+      // then
+      const answersIndexCount = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'answers_challengeId_idx\''));
+      expect(answersIndexCount).to.equal(1);
+
+    });
+
+    it('should create view students', async function() {
+      // then
+      const viewCount = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM pg_views vws WHERE vws.viewname = \'students\';'));
+      expect(viewCount).to.equal(1);
+    });
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Problème
Grâce aux PR suivantes, il n'y a presque plus de dépendances à Scalingo.
- utilisation de l'API Scalingo #61 
- remplacement du téléchargement par un backup custom #63 

Il est possible de créer un test d'acceptance pour éviter les régressions.

## :robot: Solution
Tester le composant principal steps.js / backupAndRestore

## :rainbow: Remarques
Mise à jour de la documentation pour citer l'API Airtable de test

## :100: Pour tester
Vérifier en local et sur la CI
