### PR TITLE
[TECH] Afficher les enregistrements longs sur le client natif (psql).

### DIFF
--- a/.psqlrc
+++ b/.psqlrc
@@ -1,0 +1,2 @@
+\pset format wrapped
+\pset columns 100

--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,2 @@
+test
+local-setup


### PR DESCRIPTION
## :unicorn: Problème
Si une colonne de grande taille (ex: JSONB de 60k caractères) est requêtée `psql` (via scalingo-cli), une page blanche est affichée
`SELECT ke_sn.* FROM "knowledge-element-snapshots" ke_sn WHERE ke_sn.id = 1;`

Cela peut se résoudre 
- si texte, en tronquant avec la fonction `substring`
- si JSON, en formattant avec la fonction `jsonb_pretty`

Mais cela peut devenir fastidieux

## :robot: Solution
Forcer la mise à la ligne (wrap) avec les paramètres du client natif `psql`
* pour revenir à la ligne : format = wrapped 
* au bout de 100 carcatères: columns = 100

## :rainbow: Remarques
J'ai ajouté un slugignore pour ne pas envoyer les tests sur le PAAS
Il ne faut PAS ajouter le fichier `.psqlrc` au `slugignore`, comme expliqué dans [cette PR](https://github.com/1024pix/pix/pull/2216)

## :100: Pour tester
Se connecter en RA
`scalingo -a pix-datawarehouse-pr76 pgsql-console`

Exécuter `SELECT ke_sn.* FROM "knowledge-element-snapshots" ke_sn WHERE ke_sn.id = 1;`
Vérifier l'affichage suivant

Se connecter en RA
`scalingo -a pix-datawarehouse-pr76 run bash`

Vérifier que les dossiers du `.slugignore` sont absents
