### PR TITLE
[TECH] Tracer l'origine des promesses rejetées.

### DIFF
--- a/src/replication_job.js
+++ b/src/replication_job.js
@@ -33,6 +33,10 @@ function exitOnSignal(signal) {
 }
 
 process.on('uncaughtException', () => { exitOnSignal('uncaughtException'); });
-process.on('unhandledRejection', () => { exitOnSignal('unhandledRejection'); });
+process.on('unhandledRejection', (reason, promise) => {
+  // eslint-disable-next-line no-console
+  console.log('Unhandled Rejection at:', promise, 'reason:', reason);
+  exitOnSignal('unhandledRejection');
+});
 process.on('SIGTERM', () => { exitOnSignal('SIGTERM'); });
 process.on('SIGINT', () => { exitOnSignal('SIGINT'); });

--- a/src/replication_job.js
+++ b/src/replication_job.js
@@ -34,8 +34,7 @@ function exitOnSignal(signal) {
 
 process.on('uncaughtException', () => { exitOnSignal('uncaughtException'); });
 process.on('unhandledRejection', (reason, promise) => {
-  // eslint-disable-next-line no-console
-  console.log('Unhandled Rejection at:', promise, 'reason:', reason);
+  logger.info('Unhandled Rejection at:', promise, 'reason:', reason);
   exitOnSignal('unhandledRejection');
 });
 process.on('SIGTERM', () => { exitOnSignal('SIGTERM'); });

--- a/src/run-replicate-incrementally.js
+++ b/src/run-replicate-incrementally.js
@@ -20,6 +20,10 @@ function exitOnSignal(signal) {
 }
 
 process.on('uncaughtException', () => { exitOnSignal('uncaughtException'); });
-process.on('unhandledRejection', () => { exitOnSignal('unhandledRejection'); });
+process.on('unhandledRejection', (reason, promise) => {
+  // eslint-disable-next-line no-console
+  logger.info('Unhandled Rejection at:', promise, 'reason:', reason);
+  exitOnSignal('unhandledRejection');
+});
 process.on('SIGTERM', () => { exitOnSignal('SIGTERM'); });
 process.on('SIGINT', () => { exitOnSignal('SIGINT'); });

--- a/src/run-replicate-incrementally.js
+++ b/src/run-replicate-incrementally.js
@@ -21,7 +21,6 @@ function exitOnSignal(signal) {
 
 process.on('uncaughtException', () => { exitOnSignal('uncaughtException'); });
 process.on('unhandledRejection', (reason, promise) => {
-  // eslint-disable-next-line no-console
   logger.info('Unhandled Rejection at:', promise, 'reason:', reason);
   exitOnSignal('unhandledRejection');
 });

--- a/src/run.js
+++ b/src/run.js
@@ -28,8 +28,7 @@ function exitOnSignal(signal) {
 process.on('uncaughtException', () => { exitOnSignal('uncaughtException'); });
 
 process.on('unhandledRejection', (reason, promise) => {
-  // eslint-disable-next-line no-console
-  console.log('Unhandled Rejection at:', promise, 'reason:', reason);
+  logger.info('Unhandled Rejection at:', promise, 'reason:', reason);
   exitOnSignal('unhandledRejection');
 });
 

--- a/src/run.js
+++ b/src/run.js
@@ -26,6 +26,12 @@ function exitOnSignal(signal) {
 }
 
 process.on('uncaughtException', () => { exitOnSignal('uncaughtException'); });
-process.on('unhandledRejection', () => { exitOnSignal('unhandledRejection'); });
+
+process.on('unhandledRejection', (reason, promise) => {
+  // eslint-disable-next-line no-console
+  console.log('Unhandled Rejection at:', promise, 'reason:', reason);
+  exitOnSignal('unhandledRejection');
+});
+
 process.on('SIGTERM', () => { exitOnSignal('SIGTERM'); });
 process.on('SIGINT', () => { exitOnSignal('SIGINT'); });

--- a/src/schedule-incremental-replication.js
+++ b/src/schedule-incremental-replication.js
@@ -2,7 +2,7 @@ const CronJob = require('cron').CronJob;
 const parisTimezone = 'Europe/Paris';
 
 const replicateIncrementally = require('./replicate-incrementally');
-const logger = require('../logger');
+const logger = require('./logger');
 
 const extractConfigurationFromEnvironment = require ('./extract-configuration-from-environment');
 const configuration = extractConfigurationFromEnvironment();


### PR DESCRIPTION
## :unicorn: Problème
Le rejet de certaines promesses n'alimentent pas le log de manière assez précise pour être identifiées

Exemple: `pgclientSetup` dans `src/replication_job.js`
```
async function main() {
  await steps.pgclientSetup(configuration);
  new CronJob(configuration.SCHEDULE, async function() {
    try {
      await steps.fullReplicationAndEnrichment(configuration);
    } catch (error) {
      logger.error(error);
      process.exit(1);
    }
  }, null, true, parisTimezone);
}

main()
  .catch((error) => {
    logger.error(error);
    process.exit(1);
  });
```

## :robot: Solution
Alimenter le log dans le handler de l'évènement [unhandledRejection](https://nodejs.org/api/process.html#process_event_unhandledrejection)

## :rainbow: Remarques
Est-ce vraiment la bonne solution ou dois-je rajouter un catch sur l'appel en question (ou les deux) ?
Si je rajoute ce catch, le catch du main a t-il encore une utilité ?

## :100: Pour tester
Exécuter en local `node ./src/run.js`et vérifier que l'erreur suivante est tracée
```
Unhandled Rejection at: Promise {
  <rejected> Error: spawn dbclient-fetcher ENOENT
      at Process.ChildProcess._handle.onexit (internal/child_process.js:269:19)
      at onErrorNT (internal/child_process.js:465:16)
      at processTicksAndRejections (internal/process/task_queues.js:80:21) {
    errno: -2,
    code: 'ENOENT',
    syscall: 'spawn dbclient-fetcher',
    path: 'dbclient-fetcher',
    spawnargs: [ 'pgsql', '12;' ]
  }
```