### PR TITLE
[TECH] Implémenter correctement l'installation asynchrone du client de BDD 

### DIFF
--- a/src/steps.js
+++ b/src/steps.js
@@ -74,8 +74,8 @@ function installPostgresClient(configuration) {
 }
 
 async function pgclientSetup(configuration) {
-  setupPath();
-  installPostgresClient(configuration);
+  await setupPath();
+  return installPostgresClient(configuration);
 }
 
 function dropCurrentObjects(configuration) {


### PR DESCRIPTION
## :unicorn: Problème
La fin de l'exécution asycnhrone de `installPostgresClient` est ignorée

## :robot: Solution
Attendre la fin avec `await`

## :rainbow: Remarques
Le code ne remonte pas d'erreur en production, car cette erreur intervient en local où la commande `dbclient-fetcher `est inconnue

## :100: Pour tester

Exécuter en local node ./src/run.js' 

**Avant**

Vérifier que l'erreur est tracée sans aucun détail `Received signal unhandledRejection.`
```
{"name":"pix-db-replication","hostname":"OCTO-TOPI","pid":18551,"level":30,"msg":"Start import and enrichment","time":"2021-01-15T08:23:35.337Z","v":0}
{"name":"pix-db-replication","hostname":"OCTO-TOPI","pid":18551,"level":30,"msg":"Import data from API database","time":"2021-01-15T08:23:35.338Z","v":0}
{"name":"pix-db-replication","hostname":"OCTO-TOPI","pid":18551,"level":30,"msg":"Start create Backup","time":"2021-01-15T08:23:35.339Z","v":0}
{"name":"pix-db-replication","hostname":"OCTO-TOPI","pid":18551,"level":30,"msg":"Received signal unhandledRejection.","time":"2021-01-15T08:23:35.352Z","v":0}
```

**Après**

Vérifier que l'erreur suivante est tracée
```
Unhandled Rejection at: Promise {
  <rejected> Error: spawn dbclient-fetcher ENOENT
      at Process.ChildProcess._handle.onexit (internal/child_process.js:269:19)
      at onErrorNT (internal/child_process.js:465:16)
      at processTicksAndRejections (internal/process/task_queues.js:80:21) {
    errno: -2,
    code: 'ENOENT',
    syscall: 'spawn dbclient-fetcher',
    path: 'dbclient-fetcher',
    spawnargs: [ 'pgsql', '12;' ]
  }
```
