### PR TITLE
[TECH] Ajout de données supplémentaires provenant du référentiel pour exploitation contenus

### DIFF
--- a/src/airtable-data.js
+++ b/src/airtable-data.js
@@ -61,6 +61,7 @@ const tables = [{
     { name:'firstSkillId', type:'text', extractor: (record) => _.get(record.get('Acquix (id persistant)'), 0) },
     { name:'secondSkillId', type:'text', extractor: (record) => _.get(record.get('Acquix (id persistant)'), 1) },
     { name:'thirdSkillId', type:'text', extractor: (record) => _.get(record.get('Acquix (id persistant)'), 2) },
+    { name:'languages', type:'text []', airtableName:'Langues', isArray:true },
   ],
   airtableId:'id persistant',
   indices: ['firstSkillId']

--- a/src/airtable-data.js
+++ b/src/airtable-data.js
@@ -20,6 +20,7 @@ const tables = [{
     { name:'name', type:'text', airtableName:'Référence' },
     { name:'code', type:'text', airtableName:'Sous-domaine' },
     { name:'title', type:'text', airtableName:'Titre' },
+    { name:'origin', type:'text', airtableName:'Origine' },
     { name:'areaId', type:'text', airtableName:'Domaine (id persistant)', isArray:false }
   ],
   airtableId:'id persistant',


### PR DESCRIPTION
## :unicorn: Problème
Ajout de données supplémentaires provenant du référentiel vers les tables de réplication.
Le contenu a besoin d'identifier rapidement si un acquis Pix n'a pas d'épreuves en fr. (via metabase)

## :robot: Solution
Ajout des données sur les langues des épreuves

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
