### PR TITLE
[TECH] Permettre l'exécution de l'ordonnanceur en local.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Démarrer le serveur de BDD
 docker-compose up --detach
 ````
 
-Créer et chargers les BDD
+Créer et charger les BDD
 ````shell
 npm run local:setup-databases
 ````
@@ -102,6 +102,10 @@ Vérifiez que la source et la cible sont accessibles et qu'elles contiennent des
 psql postgres://source_user@localhost/source_database
 psql postgres://target_user@localhost/target_database
 ````
+
+Installez le CLI Bull
+`npm install bull-repl -g`
+
 
 ### Paramétrage
 Créer un fichier `.env` à partir du fichier [sample.env](sample.env)
@@ -165,6 +169,69 @@ Exécuter
 ``` bash
 node ./src/run-replicate-incrementally.js 
 ```
+
+#### Ordonnanceur
+
+Il est possible de faire tourner l'ordonnanceur en local.
+
+Mettez la planification à toutes les minutes dans le fichier `.env`
+
+`SCHEDULE=* * * * *`
+
+Démarrez l'ordonnanceur
+
+`node ./src/replication_job.js | ./node_modules/.bin/bunyan`
+
+Vérifiez que le traitement se lance
+```shell
+[2021-06-11T14:11:01.944Z]  INFO: pix-db-replication/83294 on OCTO-TOPI: Starting job in Airtable replication queue: 10
+```
+Vérifiez que bull a pu joindre redis
+```shell
+redis-cli
+keys bull:*
+```
+
+Connectez-vous au CLI Bull pour suivre l'avancement.
+
+Pour la réplication par dump
+```shell
+bull-repl
+connect "Replication queue"
+stats
+```
+
+Pour la réplication incrémentale
+```shell
+bull-repl
+connect "Incremental replication queue"
+stats
+```
+
+Pour l'import Airtable
+```shell
+bull-repl
+connect "Airtable replication queue"
+stats
+```
+
+Vous obtenez, par exemple 
+- en cours d'exécution d'un traitement
+- après 14 exécution avec succès 
+
+```shell
+┌───────────┬────────┐
+│  (index)  │ Values │
+├───────────┼────────┤
+│  waiting  │   0    │
+│  active   │   1    │
+│ completed │   14   │
+│  failed   │   0    │
+│  delayed  │   0    │
+│  paused   │   0    │
+└───────────┴────────┘
+```
+
 
 ## Tests
 Une partie du code n'est pas testable de manière automatisée.

--- a/sample.env
+++ b/sample.env
@@ -31,7 +31,8 @@
 # presence: required
 # type: String
 # default: none
-NODE_ENV=development
+# sample: NODE_ENV=development
+NODE_ENV=
 
 # Version du client PG utilisé
 #
@@ -71,7 +72,8 @@ AIRTABLE_BASE=
 # presence: required
 # type: Cron
 # default: none
-SCHEDULE="10 5 * * *"
+# sample: SCHEDULE=10 5 * * *
+SCHEDULE=
 
 # Cette variable est utilisée pour indiquer le nombre maximum de tentative de
 # rejeux
@@ -95,6 +97,7 @@ PG_RESTORE_JOBS=
 # presence: required
 # type: Boolean
 # default: none
+# sample: RESTORE_FK_CONSTRAINTS=false
 RESTORE_FK_CONSTRAINTS=
 
 # Restaurer ou non les tables `answers` et `knowledge-elements`. Si non
@@ -104,6 +107,7 @@ RESTORE_FK_CONSTRAINTS=
 # presence: required
 # type: Boolean
 # default: none
+# sample: RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS=true
 RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS=
 
 # Restaurer ou non les tables `answers` et `knowledge-elements` par incrément.
@@ -116,6 +120,7 @@ RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS=
 # presence: required
 # type: Boolean
 # default: false
+# sample: RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY=true
 RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY=
 
 # Si `RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY = true`, URL de la BDD depuis

--- a/src/steps.js
+++ b/src/steps.js
@@ -35,8 +35,10 @@ function installPostgresClient(configuration) {
 }
 
 async function pgclientSetup(configuration) {
-  await setupPath();
-  return installPostgresClient(configuration);
+  if (process.env.NODE_ENV === 'production') {
+    await setupPath();
+    await installPostgresClient(configuration);
+  }
 }
 
 function dropCurrentObjects(configuration) {


### PR DESCRIPTION
## :unicorn: Problème
[Depuis le passage à Bull](https://github.com/1024pix/pix-db-replication/pull/81), il est utile de pouvoir tester l'ordonnanceur en local.

## :robot: Solution
Ne pas installer les outils spécifique au PAAS si l'exécution est locale.
Documenter l'usage des outils CLI redis/bull.

## :rainbow: Remarques
Amélioration du sample.env

## :100: Pour tester
Suivre le README.md
