### PR TITLE
[BUGFIX ] Corriger les logs sur la réplication incrémentale

### DIFF
--- a/src/replicate-incrementally.js
+++ b/src/replicate-incrementally.js
@@ -75,7 +75,7 @@ async function run(configuration) {
 
   tablesAndLastRecordIndex.forEach(async(table) => {
 
-    const maxIdStrAfterReplication = await execStdOut('psql', [configuration.TARGET_DATABASE_URL, '--tuples-only', '--command', `SELECT MAX(id) FROM ${table.name}`]);
+    const maxIdStrAfterReplication = await execStdOut('psql', [configuration.TARGET_DATABASE_URL, '--tuples-only', '--command', `SELECT MAX(id) FROM ${table.name.replace(/\\/g, '')}`]);
     const lastRecordIndexTargetAfterReplication = parseInt(maxIdStrAfterReplication);
     logger.info(`${table.name} last record index target after replication ` + lastRecordIndexTargetAfterReplication);
 


### PR DESCRIPTION
## :unicorn: Problème
Un bug dans les logs de la réplication incrémentale a été introduit par la PR #90

## :robot: Solution
Echapper les backslash dans les logs

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
