### PR TITLE
Réplication incrémentale en asynchrone

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "preinstall": "npx check-engine",
-    "test": "NODE_ENV=test mocha --exit --recursive --reporter=dot -- -timeout 600000"
+    "test": "NODE_ENV=test mocha --exit --recursive --reporter=dot --timeout 600000"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## :unicorn: Problème

Lors du passage de tous les appels externes en asynchrone (https://github.com/1024pix/pix-db-replication/pull/57) il en est un qui a réussi à échapper au couteau de @laura-bergoens : celui qui exécute le processus de copie de données pour la réplication incrémentale.

De plus, le fait de devoir construire une ligne de commande complexe avec un _pipe_ pour chaîner le processus `psql` d'extraction et celui d'insertion oblige à une gymnastique d'échappement compliquée.

Enfin, certains appels asynchrones ne sont pas correctement chaînés (pas de `await`) et pourraient mener à des échecs de promesse non interceptés : https://github.com/1024pix/pix-db-replication/blob/016ffc11a97ef3ec694c8f2b50e5a4eedc75348f/src/replicate-incrementally.js#L76

(noter que passer une fonction marquée `async` à un `forEach` est une quasi-garantie de problèmes puisque `forEach` ne retourne pas les promesses générées, qui ne peuvent donc pas être chaînées)

## :robot: Solution

On utilise `execa` plutôt que `execSync` pour démarrer les processus.
Pour éviter d'avoir à construire une ligne de commande complexe, on lance les deux processus individuellement en connectant la sortie de l'un à l'entrée de l'autre (c'est exactement ce que fait le shell).
Enfin pour éviter les problèmes de promesses non chaînées on remplace les `.forEach` par un `for(… of …)`, qui interagit correctement avec `async`/`await`.

## :rainbow: Remarques

C'était bien pratique d'avoir des tests ❤️ 
