### PR TITLE
[BUGFIX] Permettre le démarrage de l'ordonnanceur lors du premier déploiement.

### DIFF
--- a/src/replication_job.js
+++ b/src/replication_job.js
@@ -47,9 +47,15 @@ async function main() {
 async function _setInterruptedJobsAsFailed() {
   const promises = [replicationQueue, airtableReplicationQueue, incrementalReplicationQueue].map(async (queue) => {
     const activeJobs = await queue.getActive();
+
     for (const job of activeJobs) {
-      await job.moveToFailed();
+      await job.moveToFailed({ message: 'Move interrupted job in failed queue' }, true);
     }
+
+    if (activeJobs.length === 0) {
+      logger.info(`No active jobs to be marked as failed for queue ${queue.name}`);
+    }
+
   });
   return Promise.all(promises);
 }


### PR DESCRIPTION
## :unicorn: Problème
La réplication incrémentale sort en erreur
```
 ProblèmeTypeError: Cannot read property 'message' of undefined
  File "/app/node_modules/bull/lib/job.js", line 273, in Job.moveToFailed
      this.failedReason = err.message;
  File "/app/node_modules/bull/lib/queue.js", line 1084, in handleFailed
        return job.moveToFailed(err).then(jobData => {
```

Ce message est remonté par bull [lors de l'initialisation](https://github.com/OptimalBits/bull/issues/2029)

Cela est dû à la gestion du premier déploiement instauré par #81, [voir ce commentaire](https://github.com/1024pix/pix-db-replication/pull/81#issuecomment-848695041)

```
const promises = [replicationQueue, airtableReplicationQueue, incrementalReplicationQueue].map(async (queue) => {
    const activeJobs = await queue.getActive();
      for (const job of activeJobs) {
        await job.moveToFailed();
      }
```

## :robot: Solution
Prévoir le cas où aucun job n'est récupéré


## :100: Pour tester
Voir README.md
