### PR TITLE
[TECH] Prévenir la mention de comptes dans les logs.

### DIFF
--- a/src/config/extract-configuration-from-environment.js
+++ b/src/config/extract-configuration-from-environment.js
@@ -1,12 +1,8 @@
 /* eslint no-process-env: "off" */
 
-const logger = require('../logger');
-
 const extractConfigurationFromEnvironment = function() {
   loadEnvironmentVariableFromFileIfNotOnPaas();
   const extractedConfiguration = extractConfigurationFromEnvironmentVariable();
-
-  logger.info(extractedConfiguration, { extractedConfiguration });
   return extractedConfiguration;
 };
 


### PR DESCRIPTION
## :unicorn: Problème
Les variables d'environnement sont tracées, dont les credentials d'acccès aux sources de données.

## :robot: Solution
Supprimer la trace

## :rainbow: Remarques
Voir @alexandrecoin  pour savoir quel était si le besoin derrière cette trace, et s'il peut être safisfait autrement

## :100: Pour tester
Vérifier les logs dans Scalingo + Datadog