### PR TITLE
[TECH] Gérer le choix des tables de réplication via une configuration externalisée.

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -15,7 +15,7 @@ plugins:
   - mocha
 
 parserOptions:
-  ecmaVersion: 2018
+  ecmaVersion: 2020
   sourceType: script
 
 env:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ node -e "steps=require('./src/steps'); steps.importAirtableData(require ('./src/
 ##### Enrichissement
 Création index, vues..
 ``` bash
-node -e "steps=require('./src/steps'); steps.addEnrichment(require ('./src/extract-configuration-from-environment')())"
+node -e "steps=require('./src/steps'); steps.addEnrichment(require ('./src/config/extract-configuration-from-environment')())"
 ```
 
 ## Développement et exécution en local
@@ -173,7 +173,7 @@ Dans certains cas, le besoin est de relancer uniquement les opérations de fin d
 
 ##### Import AirTable
 ``` bash
-node -e "steps=require('./src/steps'); steps.importAirtableData(require ('./src/extract-configuration-from-environment')())"
+node -e "steps=require('./src/steps'); steps.importAirtableData(require ('./src/config/extract-configuration-from-environment')())"
 ```
 
 ##### Enrichissement
@@ -206,6 +206,14 @@ keys bull:*
 ```
 
 Connectez-vous au CLI Bull pour suivre l'avancement.
+
+Pour se connecter via Scalingo, utiliser le connect avec les 4 options ci-dessous.
+connect [options] <queue>
+    -h, --host <host>      Redis host for connection
+    -p, --port <port>      Redis port for connection
+    -d, --db <db>          Redis db for connection
+    --password <password>  Redis password for connection
+Puis saisir le nom de la queue.
 
 Pour la réplication par dump
 ```shell

--- a/README.md
+++ b/README.md
@@ -33,19 +33,19 @@ Des variables d'environnement sont mises en place afin de garder un seul reposit
 Alimenter les variables d'environnement documentées dans le fichier [sample.env](sample.env)
 
 Pour satisfaire les contraintes de déploiement Scalingo, le [Procfile](Procfile) déclare un conteneur de type `web` qui démarre un serveur Web "vide".
- 
-Une fois l'application créée et déployée une première fois, il faut : 
-- mettre à 0 le nombre de conteneurs de type `web` 
+
+Une fois l'application créée et déployée une première fois, il faut :
+- mettre à 0 le nombre de conteneurs de type `web`
 - mettre à 1 le nombre de conteneurs de type `background`.
 
 ### Exécution hors tâche planifiée
-Un traitement peut être lancé immédiatement (hors tâche planifiée) en exécutant un script dédié un conteneur one-off 
+Un traitement peut être lancé immédiatement (hors tâche planifiée) en exécutant un script dédié dans un conteneur one-off
 
 #### Sur la BDD destinée aux internes
 
 Deux traitements (dump et incrémentale) sont exécutés chaque nuit
 * si l'un d'eux échoue, le relancer
-* si les deux échouent, les relancer parallèle 
+* si les deux échouent, les relancer parallèlement 
 
 Lancer la réplication par dump
 ``` bash
@@ -80,7 +80,7 @@ node -e "steps=require('./src/steps'); steps.addEnrichment(require ('./src/extra
 ## Développement et exécution en local
 
 ### Installation
-Installez le dépôt 
+Installez le dépôt
 ``` bash
 git clone git@github.com:1024pix/pix-db-replication.git && cd pix-db-replication
 nvm use
@@ -117,10 +117,9 @@ Créer un fichier `.env` à partir du fichier [sample.env](sample.env)
 Modifier le .env
 ``` bash
 DATABASE_URL=postgresql://target_user@localhost/target_database
-RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS=true
+BACKUP_MODE= {}
 RESTORE_FK_CONSTRAINTS=true
-RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY=false
-``` 
+```
 
 Lancer la réplication
 ``` bash
@@ -131,7 +130,7 @@ Au bout de 5 minutes, vous devez obtenir le message
 ``` bash
 "msg":"enrichment.add - Ended","time":"2021-01-08T08:26:13.000Z","v":0}
 "msg":"Import and enrichment done","time":"2021-01-08T08:26:13.000Z","v":0}
-``` 
+```
 
 Pensez à recréer le backup sur le filesystem local, supprimé par la restauration
 ``` bash
@@ -159,15 +158,14 @@ Modifier le .env
 ``` bash
 SOURCE_DATABASE_URL=postgresql://source_user@localhost/source_database
 TARGET_DATABASE_URL=postgresql://target_user@localhost/target_database
-RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS=true
+BACKUP_MODE='{"knowledge-elements":"incremental", "knowledge-element-snapshots":"incremental","answers":"incremental"}'
 RESTORE_FK_CONSTRAINTS=false
-RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY=true
-``` 
+```
 
 ##### Exécuter
 Exécuter
 ``` bash
-node ./src/run-replicate-incrementally.js 
+node ./src/run-replicate-incrementally.js
 ```
 
 #### Exécution partielle
@@ -230,9 +228,9 @@ connect "Airtable replication queue"
 stats
 ```
 
-Vous obtenez, par exemple 
+Vous obtenez, par exemple
 - en cours d'exécution d'un traitement
-- après 14 exécution avec succès 
+- après 14 exécutions avec succès
 
 ```shell
 ┌───────────┬────────┐
@@ -251,12 +249,12 @@ Vous obtenez, par exemple
 ## Tests
 Une partie du code n'est pas testable de manière automatisée.
 Elle consiste en la récupération du backup.
-Il est donc important d'effectuer un test manuel en RA avant de merger une PR, même si la CI passe. 
- 
-### Manuels 
+Il est donc important d'effectuer un test manuel en RA avant de merger une PR, même si la CI passe.
+
+### Manuels
 
 #### Local
-Récupérer les données Airtable : 
+Récupérer les données Airtable :
 ``` bash
 node -e "steps=require('./src/steps'); steps.importAirtableData();"
 ```
@@ -296,16 +294,16 @@ SELECT id, email FROM "users" LIMIT 5;
 #### Local
 
 ##### Intégration
-Déroulement : 
+Déroulement :
 - une BDD est créée en local sur l'URL `$TEST_POSTGRES_URL` (par défaut : `postgres://postgres@localhost`), instance `pix_replication_test`
 - la table `test_table` est créée et chargée avec 100 000 enregistrements (1 colonne, PK)
-- un export est effectué par `pg_dump --c` dans un dossier temporaire 
+- un export est effectué par `pg_dump --c` dans un dossier temporaire
 - la restauration à tester est appelée depuis `steps.js/restoreBackup`
-- les assertions SQL sont effectuées par un `runSql`, un wrapper autour de `psql` 
+- les assertions SQL sont effectuées par un `runSql`, un wrapper autour de `psql`
 
 _Note :_ le dump Scalingo est créé avec des options `pg_dump` [différentes](https://doc.scalingo.com/databases/postgresql/dump-restore)
 
-- Se connecter à la BDD de test : 
+- Se connecter à la BDD de test :
 ``` bash
 psql postgres://postgres@localhost/pix_replication_test
 ```
@@ -314,26 +312,26 @@ psql postgres://postgres@localhost/pix_replication_test
 La CI exécute l'intégralité des tests (unitaire et intégration).
 
 ## Parser les logs
-L'analyse de ce qui prend du temps est complexe sur les logs brutes s'il y a : 
+L'analyse de ce qui prend du temps est complexe sur les logs brutes s'il y a :
 - plusieurs jobs de restauration (variable d'environnement`PG_RESTORE_JOBS`)
 - beaucoup de tables.
 
-Pour faciliter l'analyse, utilisez le script d'analyse de log. 
+Pour faciliter l'analyse, utilisez le script d'analyse de log.
 
 Étapes :
-* récupérer les logs 
+* récupérer les logs
 ``` bash
 scalingo --region osc-secnum-fr1 --app <NOM_APPLICATION> logs --lines 100000 > logs.txt
 ```
 
 * déterminer la date d'exécution au format `YYYY-MM-DDDD`, par exemple : `2020-10-13`
 
-* exécuter 
+* exécuter
 ``` bash
 node utils/parse-replication-logs.js ./logs.txt <DATE_EXECUTION>
 ```
 
-Exemples de résultat sur `pix-datawarehouse-production` le 22/10/2020 
+Exemples de résultat sur `pix-datawarehouse-production` le 22/10/2020
 ```  bash
 node utils/parse-replication-logs.js ./logs.txt 2020-10-22
 ```
@@ -365,7 +363,7 @@ TABLE DATA total duration : 4h 8min 7s
 	TABLE DATA answers : 0h 46min 55s
 ```
 
-S'il y a eu : 
+S'il y a eu :
 - plusieurs exécutions le même jour
 - une exécution incomplète (pas de message `Start restore` ou `Restore done`)
 

--- a/sample.env
+++ b/sample.env
@@ -104,12 +104,13 @@ RESTORE_FK_CONSTRAINTS=
 # La variable est un objet avec pour clé le nom de la table et pour valeur 'incremental' ou 'none'
 # Si 'incremental' la table sera restaurée en mode incrémental.
 # Si 'none' la table ne sera pas restaurée.
-# Pour les tables non spécifiées, elle seront restaurées intégralement
-#
+# Pour les tables non spécifiées, elles seront restaurées intégralement
+# ⚠️ le mode incrémental ne doit être utilisé que pour des tables en ajout uniquement. Si les lignes sont modifiées en source, cela ne sera pas reflété dans la réplication
+# les tables answers, knowledge-elements & knowledge-elements-snapshots sont indiquées pour le mode incrémental.
 # presence: required
 # type: json
 # default: {}
-# sample: BACKUP_MODE= {"answers":"none", "knowledge-elements":"none","knowledge-elements-snapshots":"incremental"}
+# sample: BACKUP_MODE= {"answers":"incremental", "knowledge-elements":"incremental","knowledge-elements-snapshots":"incremental"}
 BACKUP_MODE=
 
 # URL de la BDD depuis laquelle seront récupérées les données lors du mode incrémental

--- a/sample.env
+++ b/sample.env
@@ -100,31 +100,19 @@ PG_RESTORE_JOBS=
 # sample: RESTORE_FK_CONSTRAINTS=false
 RESTORE_FK_CONSTRAINTS=
 
-# Restaurer ou non les tables `answers` et `knowledge-elements`. Si non
-# renseignée, ces tables ne sont pas restaurées. Si "true", ces tables
-# sont restaurées.
+# Spécifier le mode de restauration des tables.
+# La variable est un objet avec pour clé le nom de la table et pour valeur 'incremental' ou 'none'
+# Si 'incremental' la table sera restaurée en mode incrémental.
+# Si 'none' la table ne sera pas restaurée.
+# Pour les tables non spécifiées, elle seront restaurées intégralement
 #
 # presence: required
-# type: Boolean
-# default: none
-# sample: RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS=true
-RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS=
+# type: json
+# default: {}
+# sample: BACKUP_MODE= {"answers":"none", "knowledge-elements":"none","knowledge-elements-snapshots":"incremental"}
+BACKUP_MODE=
 
-# Restaurer ou non les tables `answers` et `knowledge-elements` par incrément.
-# Si non renseignée ou false, ces tables sont supprimées à chaque restauration de dump.
-# Si renseignée à true, ces tables
-# - ne sont supprimées à chaque restauration de dump.
-# - sont restaurées par incrément en recopiant les données via une connexion à
-# la BDD source via COPY FROM/TO
-#
-# presence: required
-# type: Boolean
-# default: false
-# sample: RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY=true
-RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY=
-
-# Si `RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY = true`, URL de la BDD depuis
-# laquelle seront récupérées les données
+# URL de la BDD depuis laquelle seront récupérées les données lors du mode incrémental
 # L'utilisateur ne doit PAS etre postgres !
 #
 # presence: required
@@ -132,8 +120,7 @@ RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY=
 # default: postgresql://source_user@localhost/source_database
 SOURCE_DATABASE_URL=
 
-# Si `RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY = true`, URL de la BDD vers
-# laquelle seront dupliquées les données
+# URL de la BDD vers laquelle seront dupliquées les données lors du mode incrémental
 # L'utilisateur ne doit PAS etre postgres !
 #
 # presence: required

--- a/src/config/extract-configuration-from-environment.js
+++ b/src/config/extract-configuration-from-environment.js
@@ -1,4 +1,5 @@
 /* eslint no-process-env: "off" */
+const logger = require('../logger');
 
 const extractConfigurationFromEnvironment = function() {
   loadEnvironmentVariableFromFileIfNotOnPaas();
@@ -15,6 +16,15 @@ const loadEnvironmentVariableFromFileIfNotOnPaas = function() {
 };
 
 const extractConfigurationFromEnvironmentVariable = function() {
+  let BACKUP_MODE;
+
+  try {
+    BACKUP_MODE = process.env.BACKUP_MODE ? JSON.parse(process.env.BACKUP_MODE) : {};
+  } catch (e) {
+    logger.error('BACKUP_INCREMENTALLY should be a JSON value');
+    throw e;
+  }
+
   return {
     PG_CLIENT_VERSION: process.env.PG_CLIENT_VERSION || 12,
     RETRIES_TIMEOUT_MINUTES: extractInteger(process.env.RETRIES_TIMEOUT_MINUTES) || 180,
@@ -26,8 +36,7 @@ const extractConfigurationFromEnvironmentVariable = function() {
     MAX_TIMEOUT: extractInteger(process.env.MAX_TIMEOUT) || 900000, // 15 min
     PG_RESTORE_JOBS: extractInteger(process.env.PG_RESTORE_JOBS) || 4,
     RESTORE_FK_CONSTRAINTS: process.env.RESTORE_FK_CONSTRAINTS || 'true',
-    RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS: process.env.RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS || 'true',
-    RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY: process.env.RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY || 'false',
+    BACKUP_MODE,
     SOURCE_DATABASE_URL: process.env.SOURCE_DATABASE_URL || 'postgresql://source_user@localhost/source_database',
     TARGET_DATABASE_URL: process.env.TARGET_DATABASE_URL || 'postgresql://target_user@localhost/target_database',
     DATABASE_URL: process.env.DATABASE_URL || 'postgresql://target_user@localhost/target_database',
@@ -44,5 +53,4 @@ const extractConfigurationFromEnvironmentVariable = function() {
 const extractInteger = function(arg) {
   return parseInt(arg, 10);
 };
-
 module.exports = extractConfigurationFromEnvironment;

--- a/src/enrichment.js
+++ b/src/enrichment.js
@@ -2,32 +2,47 @@
 
 const { runDBOperation } = require('./db-connection');
 const logger = require('./logger');
+const toPairs = require('lodash/toPairs');
 
 async function add(configuration) {
   await runDBOperation(async (client) => {
-    const restoreAnswersAndKesAndKeSnapshots = configuration.BACKUP_MODE === 'false';
-    if (restoreAnswersAndKesAndKeSnapshots) {
+    const incrementalTables = _getIncrementalTables(configuration);
+    if (!incrementalTables.includes('knowledge-elements')) {
       logger.info('CREATE INDEX "knowledge-elements_createdAt_idx" - Started');
       await client.query('CREATE INDEX "knowledge-elements_createdAt_idx" on "knowledge-elements" (cast("createdAt" AT TIME ZONE \'UTC+1\' as date) DESC)');
       logger.info('CREATE INDEX "knowledge-elements_createdAt_idx" - Ended');
 
+    }
+    if (!incrementalTables.includes('knowledge-element-snapshots')) {
       logger.info('CREATE INDEX "knowledge-element-snapshots_snappedAt_idx" - Started');
       await client.query('CREATE INDEX "knowledge-element-snapshots_snappedAt_idx" on "knowledge-element-snapshots" (cast("snappedAt" AT TIME ZONE \'UTC+1\' as date) DESC)');
       logger.info('CREATE INDEX "knowledge-element-snapshots_snappedAt_idx" - Ended');
 
+    }
+    if (!incrementalTables.includes('answers')) {
       logger.info('CREATE INDEX "answers_challengeId_idx" - Started');
       await client.query('CREATE INDEX "answers_challengeId_idx" on "answers" ("challengeId")');
       logger.info('CREATE INDEX "answers_challengeId_idx" - Ended');
     }
-    logger.info('CREATE INDEX "users_createdAt_idx" - Started');
-    await client.query('CREATE INDEX "users_createdAt_idx" on "users" (cast("createdAt" AT TIME ZONE \'UTC+1\' as date) DESC)');
-    logger.info('CREATE INDEX "users_createdAt_idx" - Ended');
 
-    logger.info('CREATE VIEW students - Started');
-    await client.query('CREATE VIEW students AS SELECT * FROM "schooling-registrations"');
-    logger.info('CREATE VIEW students - Ended');
-
+    if (!incrementalTables.includes('users')) {
+      logger.info('CREATE INDEX "users_createdAt_idx" - Started');
+      await client.query('CREATE INDEX "users_createdAt_idx" on "users" (cast("createdAt" AT TIME ZONE \'UTC+1\' as date) DESC)');
+      logger.info('CREATE INDEX "users_createdAt_idx" - Ended');
+    }
+    if (!incrementalTables.includes('schooling-registrations')) {
+      logger.info('CREATE VIEW students - Started');
+      await client.query('CREATE VIEW students AS SELECT * FROM "schooling-registrations"');
+      logger.info('CREATE VIEW students - Ended');
+    }
   }, configuration);
+}
+
+function _getIncrementalTables(configuration) {
+  const tablePairs = toPairs(configuration.BACKUP_MODE);
+  return tablePairs
+    .filter(([_, mode]) => mode === 'incremental' || mode === 'none')
+    .map(([tableName, _]) => tableName);
 }
 
 module.exports = {

--- a/src/enrichment.js
+++ b/src/enrichment.js
@@ -6,31 +6,31 @@ const toPairs = require('lodash/toPairs');
 
 async function add(configuration) {
   await runDBOperation(async (client) => {
-    const incrementalTables = _getIncrementalTables(configuration);
-    if (!incrementalTables.includes('knowledge-elements')) {
+    const tablesToNotBeEnriched = _getTablesToNotBeEnriched(configuration);
+    if (!tablesToNotBeEnriched.includes('knowledge-elements')) {
       logger.info('CREATE INDEX "knowledge-elements_createdAt_idx" - Started');
       await client.query('CREATE INDEX "knowledge-elements_createdAt_idx" on "knowledge-elements" (cast("createdAt" AT TIME ZONE \'UTC+1\' as date) DESC)');
       logger.info('CREATE INDEX "knowledge-elements_createdAt_idx" - Ended');
 
     }
-    if (!incrementalTables.includes('knowledge-element-snapshots')) {
+    if (!tablesToNotBeEnriched.includes('knowledge-element-snapshots')) {
       logger.info('CREATE INDEX "knowledge-element-snapshots_snappedAt_idx" - Started');
       await client.query('CREATE INDEX "knowledge-element-snapshots_snappedAt_idx" on "knowledge-element-snapshots" (cast("snappedAt" AT TIME ZONE \'UTC+1\' as date) DESC)');
       logger.info('CREATE INDEX "knowledge-element-snapshots_snappedAt_idx" - Ended');
 
     }
-    if (!incrementalTables.includes('answers')) {
+    if (!tablesToNotBeEnriched.includes('answers')) {
       logger.info('CREATE INDEX "answers_challengeId_idx" - Started');
       await client.query('CREATE INDEX "answers_challengeId_idx" on "answers" ("challengeId")');
       logger.info('CREATE INDEX "answers_challengeId_idx" - Ended');
     }
 
-    if (!incrementalTables.includes('users')) {
+    if (!tablesToNotBeEnriched.includes('users')) {
       logger.info('CREATE INDEX "users_createdAt_idx" - Started');
       await client.query('CREATE INDEX "users_createdAt_idx" on "users" (cast("createdAt" AT TIME ZONE \'UTC+1\' as date) DESC)');
       logger.info('CREATE INDEX "users_createdAt_idx" - Ended');
     }
-    if (!incrementalTables.includes('schooling-registrations')) {
+    if (!tablesToNotBeEnriched.includes('schooling-registrations')) {
       logger.info('CREATE VIEW students - Started');
       await client.query('CREATE VIEW students AS SELECT * FROM "schooling-registrations"');
       logger.info('CREATE VIEW students - Ended');
@@ -38,7 +38,7 @@ async function add(configuration) {
   }, configuration);
 }
 
-function _getIncrementalTables(configuration) {
+function _getTablesToNotBeEnriched(configuration) {
   const tablePairs = toPairs(configuration.BACKUP_MODE);
   return tablePairs
     .filter(([_, mode]) => mode === 'incremental' || mode === 'none')

--- a/src/enrichment.js
+++ b/src/enrichment.js
@@ -5,7 +5,7 @@ const logger = require('./logger');
 
 async function add(configuration) {
   await runDBOperation(async (client) => {
-    const restoreAnswersAndKesAndKeSnapshots = configuration.RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS === 'true';
+    const restoreAnswersAndKesAndKeSnapshots = configuration.BACKUP_MODE === 'false';
     if (restoreAnswersAndKesAndKeSnapshots) {
       logger.info('CREATE INDEX "knowledge-elements_createdAt_idx" - Started');
       await client.query('CREATE INDEX "knowledge-elements_createdAt_idx" on "knowledge-elements" (cast("createdAt" AT TIME ZONE \'UTC+1\' as date) DESC)');

--- a/src/replicate-incrementally.js
+++ b/src/replicate-incrementally.js
@@ -17,7 +17,7 @@ function escapeSQLIdentifier(identifier) {
 async function run(configuration) {
   const incrementalTables = _getIncrementalTables(configuration);
   if (incrementalTables.length === 0) {
-    logger.info('Exit because BACKUP_MODE is falsy');
+    logger.info('Exit because BACKUP_MODE is not incremental');
     return;
   }
 

--- a/src/replicate-incrementally.js
+++ b/src/replicate-incrementally.js
@@ -15,8 +15,8 @@ function escapeSQLIdentifier(identifier) {
 
 async function run(configuration) {
 
-  if (!configuration.RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY || configuration.RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY === 'false') {
-    logger.info('Exit because RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY is falsy');
+  if (!configuration.BACKUP_MODE || configuration.BACKUP_MODE === 'false') {
+    logger.info('Exit because BACKUP_MODE is falsy');
     return;
   }
 

--- a/src/replicate-incrementally.js
+++ b/src/replicate-incrementally.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const execa = require('execa');
-const toPairs = require('lodash/toPairs');
+const { getIncrementalTables } = require('./steps');
 
 const logger = require('./logger');
 
@@ -15,7 +15,7 @@ function escapeSQLIdentifier(identifier) {
 }
 
 async function run(configuration) {
-  const incrementalTables = _getIncrementalTables(configuration);
+  const incrementalTables = getIncrementalTables(configuration);
   if (incrementalTables.length === 0) {
     logger.info('Exit because BACKUP_MODE is not incremental');
     return;
@@ -80,13 +80,6 @@ async function run(configuration) {
   }
 
   logger.info('Incremental replication done');
-}
-
-function _getIncrementalTables(configuration) {
-  const tablePairs = toPairs(configuration.BACKUP_MODE);
-  return tablePairs
-    .filter(([_, mode]) => mode === 'incremental')
-    .map(([tableName, _]) => tableName);
 }
 
 module.exports = {

--- a/src/replication_job.js
+++ b/src/replication_job.js
@@ -1,7 +1,6 @@
 require('dotenv').config();
 const Sentry = require('@sentry/node');
 const Queue = require('bull');
-const toPairs = require('lodash/toPairs');
 const initSentry = require('./sentry-init');
 const steps = require('./steps');
 const logger = require('./logger');
@@ -106,15 +105,8 @@ function _addQueueEventsListeners(queue) {
 }
 
 function hasIncremental(configuration) {
-  const incrementalTables = _getIncrementalTables(configuration);
+  const incrementalTables = steps.getIncrementalTables(configuration);
   return incrementalTables.length > 0;
-}
-
-function _getIncrementalTables(configuration) {
-  const tablePairs = toPairs(configuration.BACKUP_MODE);
-  return tablePairs
-    .filter(([_, mode]) => mode === 'incremental')
-    .map(([tableName, _]) => tableName);
 }
 
 async function _flushSentryAndExit() {

--- a/src/replication_job.js
+++ b/src/replication_job.js
@@ -28,7 +28,7 @@ async function main() {
   });
 
   incrementalReplicationQueue.process(async function() {
-    if (configuration.RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY === 'true') {
+    if (configuration.BACKUP_MODE === 'true') {
       await replicateIncrementally.run(configuration);
     }
     airtableReplicationQueue.add({}, jobOptions);
@@ -109,4 +109,3 @@ async function _flushSentryAndExit() {
   await Sentry.close(TIMEOUT);
   process.exit(1);
 }
-

--- a/src/steps.js
+++ b/src/steps.js
@@ -44,7 +44,7 @@ async function pgclientSetup(configuration) {
 
 async function dropCurrentObjects(configuration) {
   // TODO: pass DATABASE_URL by argument
-  const incrementalTables = _getIncrementalTables(configuration);
+  const incrementalTables = getIncrementalTables(configuration);
   if (incrementalTables.length > 0) {
     return dropCurrentObjectsExceptTables(configuration.DATABASE_URL, incrementalTables);
   }
@@ -94,7 +94,7 @@ async function createBackup(configuration) {
   const backupFilename = './dump.pgsql';
 
   let excludeOptions = [];
-  const incrementalTables = _getIncrementalTables(configuration);
+  const incrementalTables = getIncrementalTables(configuration);
   if (incrementalTables.length > 0) {
     excludeOptions = incrementalTables.reduce((excludeTablesOptions, tableName) => [...excludeTablesOptions, '--exclude-table', tableName], []);
   }
@@ -173,7 +173,7 @@ function _filterObjectLines(objectLines, configuration) {
     patternsToFilter.push('FK CONSTRAINT');
   }
 
-  const incrementalTables = _getIncrementalTables(configuration);
+  const incrementalTables = getIncrementalTables(configuration);
   if (incrementalTables.length > 0) {
     const prepareTableNameForRegex = (tableName) => tableName.split(/[-_]/).join('[-_]');
     const tableNamesForRegex = incrementalTables.map(prepareTableNameForRegex);
@@ -185,7 +185,7 @@ function _filterObjectLines(objectLines, configuration) {
   return objectLines.filter((line) => !new RegExp(regexp).test(line));
 }
 
-function _getIncrementalTables(configuration) {
+function getIncrementalTables(configuration) {
   const tablePairs = toPairs(configuration.BACKUP_MODE);
   return tablePairs
     .filter(([_, mode]) => mode === 'incremental')
@@ -198,6 +198,7 @@ module.exports = {
   createBackup,
   dropObjectAndRestoreBackup,
   fullReplicationAndEnrichment,
+  getIncrementalTables,
   importAirtableData,
   pgclientSetup,
   restoreBackup,

--- a/src/steps.js
+++ b/src/steps.js
@@ -87,7 +87,7 @@ async function createBackup(configuration) {
   logger.info('Start create Backup');
   const backupFilename = './dump.pgsql';
 
-  const excludeOptions = configuration.RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS === 'true'
+  const excludeOptions = configuration.BACKUP_MODE === 'false'
     ? []
     : [
       '--exclude-table', 'knowledge-elements',
@@ -117,7 +117,7 @@ async function createBackup(configuration) {
 
 async function dropObjectAndRestoreBackup(backupFile, configuration) {
   logger.info('Start drop Objects AndRestoreBackup');
-  if (configuration.RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY && configuration.RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY === 'true') {
+  if (configuration.BACKUP_MODE && configuration.BACKUP_MODE === 'true') {
     await dropCurrentObjectsButKesAndAnswers(configuration);
   } else {
     await dropCurrentObjects(configuration);
@@ -165,7 +165,7 @@ async function fullReplicationAndEnrichment(configuration) {
 
 function _filterObjectLines(objectLines, configuration) {
   const restoreFkConstraints = configuration.RESTORE_FK_CONSTRAINTS === 'true';
-  const restoreAnswersAndKesAndKeSnapshots = configuration.RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS === 'true';
+  const restoreAnswersAndKesAndKeSnapshots = configuration.BACKUP_MODE === 'false';
   let filteredObjectLines = objectLines
     .filter((line) => !/ COMMENT /.test(line));
   if (!restoreFkConstraints) {

--- a/src/steps.js
+++ b/src/steps.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const airtableData = require('./airtable-data');
 const enrichment = require('./enrichment');
 const logger = require('./logger');
+const toPairs = require('lodash/toPairs');
 
 const RESTORE_LIST_FILENAME = 'restore.list';
 
@@ -41,16 +42,21 @@ async function pgclientSetup(configuration) {
   }
 }
 
-function dropCurrentObjects(configuration) {
+async function dropCurrentObjects(configuration) {
   // TODO: pass DATABASE_URL by argument
-  return exec('psql', [ configuration.DATABASE_URL, ' --echo-all', '--set', 'ON_ERROR_STOP=on', '--command', 'DROP OWNED BY CURRENT_USER CASCADE' ]);
+  const incrementalTables = _getIncrementalTables(configuration);
+  if (incrementalTables.length > 0) {
+    return dropCurrentObjectsExceptTables(configuration.DATABASE_URL, incrementalTables);
+  }
+  else return exec('psql', [ configuration.DATABASE_URL, ' --echo-all', '--set', 'ON_ERROR_STOP=on', '--command', 'DROP OWNED BY CURRENT_USER CASCADE' ]);
 }
 
-async function dropCurrentObjectsButKesAndAnswers(configuration) {
-  const dropTableQuery = await execStdOut('psql', [ configuration.DATABASE_URL, '--tuples-only', '--command', 'select string_agg(\'drop table "\' || tablename || \'" CASCADE\', \'; \') from pg_tables where schemaname = \'public\' and tablename not in (\'knowledge-elements\',\'knowledge-element-snapshots\', \'answers\');' ]);
-  const dropFunction = await execStdOut('psql', [ configuration.DATABASE_URL, '--tuples-only', '--command', 'select string_agg(\'drop function "\' || proname || \'"\', \'; \') FROM pg_proc pp INNER JOIN pg_roles pr ON pp.proowner = pr.oid WHERE pr.rolname = current_user ' ]);
-  await exec('psql', [ configuration.DATABASE_URL, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropTableQuery ]);
-  return exec('psql', [ configuration.DATABASE_URL, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropFunction ]);
+async function dropCurrentObjectsExceptTables(databaseUrl, tableNames) {
+  const tableNamesForQuery = tableNames.map((tableName) => `'${tableName}'`).join(',');
+  const dropTableQuery = await execStdOut('psql', [ databaseUrl, '--tuples-only', '--command', `select string_agg('drop table "' || tablename || '" CASCADE', '; ') from pg_tables where schemaname = 'public' and tablename not in (${tableNamesForQuery});` ]);
+  const dropFunction = await execStdOut('psql', [ databaseUrl, '--tuples-only', '--command', 'select string_agg(\'drop function "\' || proname || \'"\', \'; \') FROM pg_proc pp INNER JOIN pg_roles pr ON pp.proowner = pr.oid WHERE pr.rolname = current_user ' ]);
+  await exec('psql', [ databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropTableQuery ]);
+  return exec('psql', [ databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropFunction ]);
 }
 
 async function writeListFileForReplication({ backupFile, configuration }) {
@@ -87,13 +93,12 @@ async function createBackup(configuration) {
   logger.info('Start create Backup');
   const backupFilename = './dump.pgsql';
 
-  const excludeOptions = configuration.BACKUP_MODE === 'false'
-    ? []
-    : [
-      '--exclude-table', 'knowledge-elements',
-      '--exclude-table', 'knowledge-element-snapshots',
-      '--exclude-table', 'answers',
-    ];
+  let excludeOptions = [];
+  const incrementalTables = _getIncrementalTables(configuration);
+  if (incrementalTables.length > 0) {
+    excludeOptions = incrementalTables.reduce((excludeTablesOptions, tableName) => [...excludeTablesOptions, '--exclude-table', tableName], []);
+  }
+
   const verboseOptions = process.env.NODE_ENV === 'test' ? [] : ['--verbose'];
 
   await exec('pg_dump', [
@@ -117,11 +122,7 @@ async function createBackup(configuration) {
 
 async function dropObjectAndRestoreBackup(backupFile, configuration) {
   logger.info('Start drop Objects AndRestoreBackup');
-  if (configuration.BACKUP_MODE && configuration.BACKUP_MODE === 'true') {
-    await dropCurrentObjectsButKesAndAnswers(configuration);
-  } else {
-    await dropCurrentObjects(configuration);
-  }
+  await dropCurrentObjects(configuration);
   logger.info('End drop Objects AndRestoreBackup');
 
   logger.info('Start restore Backup');
@@ -164,22 +165,31 @@ async function fullReplicationAndEnrichment(configuration) {
 }
 
 function _filterObjectLines(objectLines, configuration) {
+  const patternsToFilter = [' COMMENT '];
+
   const restoreFkConstraints = configuration.RESTORE_FK_CONSTRAINTS === 'true';
-  const restoreAnswersAndKesAndKeSnapshots = configuration.BACKUP_MODE === 'false';
-  let filteredObjectLines = objectLines
-    .filter((line) => !/ COMMENT /.test(line));
+
   if (!restoreFkConstraints) {
-    filteredObjectLines = filteredObjectLines.filter((line) => !/FK CONSTRAINT/.test(line));
-  }
-  if (!restoreAnswersAndKesAndKeSnapshots) {
-    filteredObjectLines = filteredObjectLines
-      .filter((line) => !/answers/.test(line))
-      .filter((line) => !/knowledge-elements/.test(line))
-      .filter((line) => !/knowledge-element-snapshots/.test(line))
-      .filter((line) => !/knowledge_elements/.test(line));
+    patternsToFilter.push('FK CONSTRAINT');
   }
 
-  return filteredObjectLines;
+  const incrementalTables = _getIncrementalTables(configuration);
+  if (incrementalTables.length > 0) {
+    const prepareTableNameForRegex = (tableName) => tableName.split(/[-_]/).join('[-_]');
+    const tableNamesForRegex = incrementalTables.map(prepareTableNameForRegex);
+    patternsToFilter.push(...tableNamesForRegex);
+  }
+
+  const regexp = patternsToFilter.join('|');
+
+  return objectLines.filter((line) => !new RegExp(regexp).test(line));
+}
+
+function _getIncrementalTables(configuration) {
+  const tablePairs = toPairs(configuration.BACKUP_MODE);
+  return tablePairs
+    .filter(([_, mode]) => mode === 'incremental')
+    .map(([tableName, _]) => tableName);
 }
 
 module.exports = {

--- a/test/acceptance/full-dump-replication-test.js
+++ b/test/acceptance/full-dump-replication-test.js
@@ -27,7 +27,7 @@ describe('Acceptance | steps | fullReplicationAndEnrichment', () => {
     SOURCE_DATABASE_URL,
     TARGET_DATABASE_URL,
     DATABASE_URL: TARGET_DATABASE_URL,
-    BACKUP_MODE: 'false',
+    BACKUP_MODE: {},
     PG_RESTORE_JOBS: 1,
     AIRTABLE_API_KEY: 'keyblo10ZCvCqBAJg',
     AIRTABLE_BASE: 'app3fvsqhtHJntXaC',

--- a/test/acceptance/full-dump-replication-test.js
+++ b/test/acceptance/full-dump-replication-test.js
@@ -27,7 +27,7 @@ describe('Acceptance | steps | fullReplicationAndEnrichment', () => {
     SOURCE_DATABASE_URL,
     TARGET_DATABASE_URL,
     DATABASE_URL: TARGET_DATABASE_URL,
-    RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS: 'true',
+    BACKUP_MODE: 'false',
     PG_RESTORE_JOBS: 1,
     AIRTABLE_API_KEY: 'keyblo10ZCvCqBAJg',
     AIRTABLE_BASE: 'app3fvsqhtHJntXaC',

--- a/test/integration/enrichment_test.js
+++ b/test/integration/enrichment_test.js
@@ -39,7 +39,7 @@ describe('Integration | enrichment.js', () => {
         await createAndFillDatabase(database, databaseConfig, { createTablesNotToBeImported: true });
 
         // when
-        const configuration = { RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS: 'true', DATABASE_URL: databaseConfig.databaseUrl };
+        const configuration = { BACKUP_MODE: 'false', DATABASE_URL: databaseConfig.databaseUrl };
         await add(configuration);
 
         // then
@@ -54,7 +54,7 @@ describe('Integration | enrichment.js', () => {
         await createAndFillDatabase(database, databaseConfig, { createTablesNotToBeImported: true });
 
         // when
-        const configuration = { RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS: 'true', DATABASE_URL: databaseConfig.databaseUrl };
+        const configuration = { BACKUP_MODE: 'false', DATABASE_URL: databaseConfig.databaseUrl };
         await add(configuration);
 
         // then
@@ -77,7 +77,7 @@ describe('Integration | enrichment.js', () => {
         await createAndFillDatabase(database, databaseConfig, { createTablesNotToBeImported: true });
 
         // when
-        const configuration = { RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS: 'true', DATABASE_URL: databaseConfig.databaseUrl };
+        const configuration = { BACKUP_MODE: 'false', DATABASE_URL: databaseConfig.databaseUrl };
         await add(configuration);
 
         // then

--- a/test/integration/enrichment_test.js
+++ b/test/integration/enrichment_test.js
@@ -25,76 +25,63 @@ describe('Integration | enrichment.js', () => {
 
   describe('add', function() {
 
-    context('whatever options are provided', () => {
-      let database;
-
-      afterEach(() => {
-        database.dropDatabase();
-      });
-
-      it('create index users_createdAt_idx', async function() {
-
-        // given
-        database = await Database.create(databaseConfig);
-        await createAndFillDatabase(database, databaseConfig, { createTablesNotToBeImported: true });
-
-        // when
-        const configuration = { BACKUP_MODE: 'false', DATABASE_URL: databaseConfig.databaseUrl };
-        await add(configuration);
-
-        // then
-        const indexCount = parseInt(await database.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'users_createdAt_idx\''));
-        expect(indexCount).to.equal(1);
-      });
-
-      it('create view students', async function() {
-
-        // given
-        database = await Database.create(databaseConfig);
-        await createAndFillDatabase(database, databaseConfig, { createTablesNotToBeImported: true });
-
-        // when
-        const configuration = { BACKUP_MODE: 'false', DATABASE_URL: databaseConfig.databaseUrl };
-        await add(configuration);
-
-        // then
-        const viewCount = parseInt(await database.runSql('SELECT COUNT(1) FROM pg_views vws WHERE vws.viewname = \'students\';'));
-        expect(viewCount).to.equal(1);
-      });
-
-    });
-
     context('according to environment variables', () => {
       let database;
 
-      afterEach(() => {
+      after(() => {
         database.dropDatabase();
       });
 
-      it('does create these indexes', async function() {
-        // given
-        database = await Database.create(databaseConfig);
-        await createAndFillDatabase(database, databaseConfig, { createTablesNotToBeImported: true });
+      [
+        {
+          mode: 'none',
+          itLabel: 'should not create indexes for tables on "none" mode',
+          tables: ['knowledge-elements', 'knowledge-element-snapshots', 'answers', 'users', 'schooling-registrations'],
+          'indexCount': 0,
+        },
+        {
+          mode: 'incremental',
+          itLabel: 'should not create indexes for tables on "incremental" mode',
+          tables: ['knowledge-elements', 'knowledge-element-snapshots', 'answers', 'users', 'schooling-registrations'],
+          'indexCount': 0,
+        },
+        {
+          mode: '',
+          itLabel: 'should create indexes for tables not specified in var env',
+          tables: [],
+          'indexCount': 1,
+        },
+      ].forEach(({ mode, itLabel, tables, indexCount }) =>
+        it(itLabel, async function() {
+          // given
+          database = await Database.create(databaseConfig);
+          await createAndFillDatabase(database, databaseConfig, { createTablesNotToBeImported: true });
 
-        // when
-        const configuration = { BACKUP_MODE: 'false', DATABASE_URL: databaseConfig.databaseUrl };
-        await add(configuration);
+          // when
+          const BACKUP_MODE = tables.reduce((tablesObject, tableName) =>
+            ({ ...tablesObject, [tableName]: mode }), {});
+          const configuration = { BACKUP_MODE, DATABASE_URL: databaseConfig.databaseUrl };
+          await add(configuration);
 
-        // then
-        const KEIndexCount = parseInt(await database.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'knowledge-elements_createdAt_idx\''));
-        expect(KEIndexCount).to.equal(1);
+          // then
+          const KEIndexCount = parseInt(await database.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'knowledge-elements_createdAt_idx\''));
+          expect(KEIndexCount).to.equal(indexCount);
 
-        // then
-        const KESnapshotsIndexCount = parseInt(await database.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'knowledge-element-snapshots_snappedAt_idx\''));
-        expect(KESnapshotsIndexCount).to.equal(1);
+          // then
+          const KESnapshotsIndexCount = parseInt(await database.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'knowledge-element-snapshots_snappedAt_idx\''));
+          expect(KESnapshotsIndexCount).to.equal(indexCount);
 
-        // then
-        const answersIndexCount = parseInt(await database.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'answers_challengeId_idx\''));
-        expect(answersIndexCount).to.equal(1);
-      });
+          // then
+          const answersIndexCount = parseInt(await database.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'answers_challengeId_idx\''));
+          expect(answersIndexCount).to.equal(indexCount);
 
+          const usersIndexCount = parseInt(await database.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'users_createdAt_idx\''));
+          expect(usersIndexCount).to.equal(indexCount);
+
+          const viewCount = parseInt(await database.runSql('SELECT COUNT(1) FROM pg_views vws WHERE vws.viewname = \'students\';'));
+          expect(viewCount).to.equal(indexCount);
+        }));
     });
-
   });
 
 });

--- a/test/integration/replicate-incrementally-test.js
+++ b/test/integration/replicate-incrementally-test.js
@@ -98,7 +98,7 @@ describe('Integration | replicate-incrementally.js', () => {
           targetDatabase = await Database.create(targetDatabaseConfig);
 
           // TODO: do not use production code to setup environment
-          const firstDayConfiguration = { RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS: 'true', RESTORE_FK_CONSTRAINTS: 'false', RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY: undefined, PG_RESTORE_JOBS: 4 };
+          const firstDayConfiguration = { BACKUP_MODE : 'false', RESTORE_FK_CONSTRAINTS: 'false', PG_RESTORE_JOBS: 4 };
           await steps.restoreBackup({ backupFile, databaseUrl: targetDatabaseConfig.databaseUrl, configuration: firstDayConfiguration });
 
           // Day 2
@@ -113,7 +113,7 @@ describe('Integration | replicate-incrementally.js', () => {
 
           const configuration = { SOURCE_DATABASE_URL: SOURCE_DATABASE_URL,
             TARGET_DATABASE_URL: TARGET_DATABASE_URL,
-            RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY: 'true',
+            BACKUP_MODE: 'true',
             PG_RESTORE_JOBS: 4 };
 
           // when
@@ -135,7 +135,7 @@ describe('Integration | replicate-incrementally.js', () => {
         targetDatabase = await Database.create(targetDatabaseConfig);
 
         // TODO: do not use production code to setup environment
-        const firstDayConfiguration = { RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS: 'true', RESTORE_FK_CONSTRAINTS: 'false', RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY: undefined, PG_RESTORE_JOBS: 4 };
+        const firstDayConfiguration = { BACKUP_MODE : 'false', RESTORE_FK_CONSTRAINTS: 'false', PG_RESTORE_JOBS: 4 };
         await steps.restoreBackup({ backupFile, databaseUrl: targetDatabaseConfig.databaseUrl, configuration: firstDayConfiguration });
 
         const answersCountBefore = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM answers'));
@@ -160,7 +160,7 @@ describe('Integration | replicate-incrementally.js', () => {
         await sourceDatabase.runSql('INSERT INTO "knowledge-element-snapshots"  (id, "userId", "snappedAt", "snapshot") VALUES (3, 2, CURRENT_TIMESTAMP, \'{"id": "3"}\'::jsonb)');
 
         // given
-        const configuration = { SOURCE_DATABASE_URL: SOURCE_DATABASE_URL, TARGET_DATABASE_URL: TARGET_DATABASE_URL, RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY: 'true', PG_RESTORE_JOBS: 4 };
+        const configuration = { SOURCE_DATABASE_URL: SOURCE_DATABASE_URL, TARGET_DATABASE_URL: TARGET_DATABASE_URL, BACKUP_MODE: 'true', PG_RESTORE_JOBS: 4 };
 
         // when
         await run(configuration);

--- a/test/integration/steps_test.js
+++ b/test/integration/steps_test.js
@@ -55,7 +55,11 @@ describe('Integration | steps.js', () => {
         SOURCE_DATABASE_URL,
         TARGET_DATABASE_URL,
         DATABASE_URL: TARGET_DATABASE_URL,
-        BACKUP_MODE: 'true',
+        BACKUP_MODE: {
+          'knowledge-elements': 'incremental',
+          'knowledge-element-snapshots': 'incremental',
+          'answers': 'incremental',
+        },
         PG_RESTORE_JOBS: 1,
       };
       sourceDatabase = await Database.create(sourceDatabaseConfig);
@@ -83,7 +87,7 @@ describe('Integration | steps.js', () => {
         SOURCE_DATABASE_URL,
         TARGET_DATABASE_URL,
         DATABASE_URL: TARGET_DATABASE_URL,
-        BACKUP_MODE: 'false',
+        BACKUP_MODE: {},
         PG_RESTORE_JOBS: 1,
       };
       sourceDatabase = await Database.create(sourceDatabaseConfig);
@@ -168,7 +172,15 @@ describe('Integration | steps.js', () => {
             // given
             database = await Database.create(databaseConfig);
             const backupFile = await createBackupAndCreateEmptyDatabase(database, databaseConfig, { createTablesNotToBeImported: true });
-            const configuration = { BACKUP_MODE: 'true', RESTORE_FK_CONSTRAINTS: 'false', PG_RESTORE_JOBS: 4 };
+            const configuration = {
+              BACKUP_MODE: {
+                'knowledge-elements': 'incremental',
+                'knowledge-element-snapshots': 'incremental',
+                'answers': 'incremental',
+              },
+              RESTORE_FK_CONSTRAINTS: 'false',
+              PG_RESTORE_JOBS: 4,
+            };
 
             // when
             await steps.restoreBackup({ backupFile, databaseUrl: databaseConfig.databaseUrl, configuration });
@@ -198,7 +210,11 @@ describe('Integration | steps.js', () => {
             // given
             database = await Database.create(databaseConfig);
             const backupFile = await createBackupAndCreateEmptyDatabase(database, databaseConfig, { createTablesNotToBeImported: true });
-            const configuration = { BACKUP_MODE: 'false', RESTORE_FK_CONSTRAINTS: 'false', PG_RESTORE_JOBS: 4 };
+            const configuration = {
+              BACKUP_MODE: {},
+              RESTORE_FK_CONSTRAINTS: 'false',
+              PG_RESTORE_JOBS: 4,
+            };
 
             // when
             await steps.restoreBackup({ backupFile, databaseUrl: databaseConfig.databaseUrl, configuration });
@@ -354,7 +370,10 @@ describe('Integration | steps.js', () => {
         // given
 
         // Day 1
-        const firstDayConfiguration = { BACKUP_MODE : 'false', PG_RESTORE_JOBS: 4 };
+        const firstDayConfiguration = {
+          BACKUP_MODE: {},
+          PG_RESTORE_JOBS: 4,
+        };
         await createBackUpFromSourceAndRestoreToTarget(sourceDatabase, sourceDatabaseConfig, targetDatabaseConfig.databaseUrl, firstDayConfiguration);
 
         const answersCountBefore = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM answers'));
@@ -373,7 +392,15 @@ describe('Integration | steps.js', () => {
         const secondDayBackupFile = await createBackup(sourceDatabase, sourceDatabaseConfig, { createTablesNotToBeImported: true });
 
         // when
-        const secondDayConfiguration = { BACKUP_MODE: 'true', DATABASE_URL: targetDatabase._databaseUrl, PG_RESTORE_JOBS: 4 };
+        const secondDayConfiguration = {
+          BACKUP_MODE: {
+            'knowledge-elements': 'incremental',
+            'knowledge-element-snapshots': 'incremental',
+            'answers': 'incremental',
+          },
+          DATABASE_URL: targetDatabase._databaseUrl,
+          PG_RESTORE_JOBS: 4,
+        };
         await steps.dropObjectAndRestoreBackup(secondDayBackupFile, secondDayConfiguration);
 
         // then
@@ -403,7 +430,7 @@ describe('Integration | steps.js', () => {
           PG_RESTORE_JOBS: 4,
           DATABASE_URL: targetDatabase._databaseUrl,
           RESTORE_FK_CONSTRAINTS: 'true',
-          BACKUP_MODE: 'false',
+          BACKUP_MODE: {},
         };
 
         await steps.dropObjectAndRestoreBackup(firstDaySourceBackupFile, firstDayTargetConfiguration);
@@ -423,7 +450,10 @@ describe('Integration | steps.js', () => {
           PG_RESTORE_JOBS: 4,
           DATABASE_URL: targetDatabase._databaseUrl,
           RESTORE_FK_CONSTRAINTS: 'false',
-          BACKUP_MODE: 'true',
+          BACKUP_MODE: {
+            'knowledge-elements': 'incremental',
+            'knowledge-element-snapshots': 'incremental',
+            'answers': 'incremental' },
         };
 
         // when
@@ -435,7 +465,6 @@ describe('Integration | steps.js', () => {
 
         const referencingCountAfter = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM referencing'));
         expect(referencingCountAfter).to.equal(referencingCountBefore + 1);
-
       });
     });
 
@@ -443,14 +472,22 @@ describe('Integration | steps.js', () => {
       // given
 
       // Day 1
-      const firstDayTargetConfiguration = { BACKUP_MODE : 'false', PG_RESTORE_JOBS: 4 };
+      const firstDayTargetConfiguration = { BACKUP_MODE: {}, PG_RESTORE_JOBS: 4 };
       await createBackUpFromSourceAndRestoreToTarget(sourceDatabase, sourceDatabaseConfig, targetDatabaseConfig.databaseUrl, firstDayTargetConfiguration);
       await sourceDatabase.dropDatabase();
 
       // Day 2
       sourceDatabase = await Database.create(sourceDatabaseConfig);
       const secondDayBackupFile = await createBackup(sourceDatabase, sourceDatabaseConfig, { createTablesNotToBeImported: true, createFunction: true });
-      const secondDayTargetConfiguration = { BACKUP_MODE: 'true', DATABASE_URL: targetDatabase._databaseUrl, PG_RESTORE_JOBS: 4 };
+      const secondDayTargetConfiguration = {
+        BACKUP_MODE: {
+          'knowledge-elements': 'incremental',
+          'knowledge-element-snapshots': 'incremental',
+          'answers': 'incremental',
+        },
+        DATABASE_URL: targetDatabase._databaseUrl,
+        PG_RESTORE_JOBS: 4,
+      };
 
       const dropObjectAndRestoreBackupWithArguments = function() {
         steps.dropObjectAndRestoreBackup(secondDayBackupFile, secondDayTargetConfiguration);
@@ -569,7 +606,11 @@ describe('Integration | steps.js', () => {
     it('should create a file', async () => {
       // given
       const configuration = {
-        BACKUP_MODE: 'true',
+        BACKUP_MODE: {
+          'knowledge-elements': 'incremental',
+          'knowledge-element-snapshots': 'incremental',
+          'answers': 'incremental',
+        },
         SOURCE_DATABASE_URL,
       };
 

--- a/test/integration/steps_test.js
+++ b/test/integration/steps_test.js
@@ -55,7 +55,7 @@ describe('Integration | steps.js', () => {
         SOURCE_DATABASE_URL,
         TARGET_DATABASE_URL,
         DATABASE_URL: TARGET_DATABASE_URL,
-        RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS: 'false',
+        BACKUP_MODE: 'true',
         PG_RESTORE_JOBS: 1,
       };
       sourceDatabase = await Database.create(sourceDatabaseConfig);
@@ -83,7 +83,7 @@ describe('Integration | steps.js', () => {
         SOURCE_DATABASE_URL,
         TARGET_DATABASE_URL,
         DATABASE_URL: TARGET_DATABASE_URL,
-        RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS: 'true',
+        BACKUP_MODE: 'false',
         PG_RESTORE_JOBS: 1,
       };
       sourceDatabase = await Database.create(sourceDatabaseConfig);
@@ -168,7 +168,7 @@ describe('Integration | steps.js', () => {
             // given
             database = await Database.create(databaseConfig);
             const backupFile = await createBackupAndCreateEmptyDatabase(database, databaseConfig, { createTablesNotToBeImported: true });
-            const configuration = { RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS: undefined, RESTORE_FK_CONSTRAINTS: 'false', PG_RESTORE_JOBS: 4 };
+            const configuration = { BACKUP_MODE: 'true', RESTORE_FK_CONSTRAINTS: 'false', PG_RESTORE_JOBS: 4 };
 
             // when
             await steps.restoreBackup({ backupFile, databaseUrl: databaseConfig.databaseUrl, configuration });
@@ -198,7 +198,7 @@ describe('Integration | steps.js', () => {
             // given
             database = await Database.create(databaseConfig);
             const backupFile = await createBackupAndCreateEmptyDatabase(database, databaseConfig, { createTablesNotToBeImported: true });
-            const configuration = { RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS: 'true', RESTORE_FK_CONSTRAINTS: 'false', PG_RESTORE_JOBS: 4 };
+            const configuration = { BACKUP_MODE: 'false', RESTORE_FK_CONSTRAINTS: 'false', PG_RESTORE_JOBS: 4 };
 
             // when
             await steps.restoreBackup({ backupFile, databaseUrl: databaseConfig.databaseUrl, configuration });
@@ -354,7 +354,7 @@ describe('Integration | steps.js', () => {
         // given
 
         // Day 1
-        const firstDayConfiguration = { RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS: 'true', PG_RESTORE_JOBS: 4 };
+        const firstDayConfiguration = { BACKUP_MODE : 'false', PG_RESTORE_JOBS: 4 };
         await createBackUpFromSourceAndRestoreToTarget(sourceDatabase, sourceDatabaseConfig, targetDatabaseConfig.databaseUrl, firstDayConfiguration);
 
         const answersCountBefore = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM answers'));
@@ -373,7 +373,7 @@ describe('Integration | steps.js', () => {
         const secondDayBackupFile = await createBackup(sourceDatabase, sourceDatabaseConfig, { createTablesNotToBeImported: true });
 
         // when
-        const secondDayConfiguration = { RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY: 'true', DATABASE_URL: targetDatabase._databaseUrl, PG_RESTORE_JOBS: 4 };
+        const secondDayConfiguration = { BACKUP_MODE: 'true', DATABASE_URL: targetDatabase._databaseUrl, PG_RESTORE_JOBS: 4 };
         await steps.dropObjectAndRestoreBackup(secondDayBackupFile, secondDayConfiguration);
 
         // then
@@ -403,8 +403,7 @@ describe('Integration | steps.js', () => {
           PG_RESTORE_JOBS: 4,
           DATABASE_URL: targetDatabase._databaseUrl,
           RESTORE_FK_CONSTRAINTS: 'true',
-          RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS: 'true',
-          RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY: 'false',
+          BACKUP_MODE: 'false',
         };
 
         await steps.dropObjectAndRestoreBackup(firstDaySourceBackupFile, firstDayTargetConfiguration);
@@ -424,8 +423,7 @@ describe('Integration | steps.js', () => {
           PG_RESTORE_JOBS: 4,
           DATABASE_URL: targetDatabase._databaseUrl,
           RESTORE_FK_CONSTRAINTS: 'false',
-          RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS: 'false',
-          RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY: 'true',
+          BACKUP_MODE: 'true',
         };
 
         // when
@@ -445,14 +443,14 @@ describe('Integration | steps.js', () => {
       // given
 
       // Day 1
-      const firstDayTargetConfiguration = { RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS: 'true', PG_RESTORE_JOBS: 4 };
+      const firstDayTargetConfiguration = { BACKUP_MODE : 'false', PG_RESTORE_JOBS: 4 };
       await createBackUpFromSourceAndRestoreToTarget(sourceDatabase, sourceDatabaseConfig, targetDatabaseConfig.databaseUrl, firstDayTargetConfiguration);
       await sourceDatabase.dropDatabase();
 
       // Day 2
       sourceDatabase = await Database.create(sourceDatabaseConfig);
       const secondDayBackupFile = await createBackup(sourceDatabase, sourceDatabaseConfig, { createTablesNotToBeImported: true, createFunction: true });
-      const secondDayTargetConfiguration = { RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY: 'true', DATABASE_URL: targetDatabase._databaseUrl, PG_RESTORE_JOBS: 4 };
+      const secondDayTargetConfiguration = { BACKUP_MODE: 'true', DATABASE_URL: targetDatabase._databaseUrl, PG_RESTORE_JOBS: 4 };
 
       const dropObjectAndRestoreBackupWithArguments = function() {
         steps.dropObjectAndRestoreBackup(secondDayBackupFile, secondDayTargetConfiguration);
@@ -571,7 +569,7 @@ describe('Integration | steps.js', () => {
     it('should create a file', async () => {
       // given
       const configuration = {
-        RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS: false,
+        BACKUP_MODE: 'true',
         SOURCE_DATABASE_URL,
       };
 

--- a/test/unit/steps_test.js
+++ b/test/unit/steps_test.js
@@ -23,7 +23,7 @@ describe('Unit | steps.js', () => {
       // given
       const configuration = {
         SOURCE_DATABASE_URL: 'postgresql://source.url',
-        RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS: 'true',
+        BACKUP_MODE: 'false',
       };
 
       // when
@@ -55,7 +55,7 @@ describe('Unit | steps.js', () => {
         // given
         const configuration = {
           SOURCE_DATABASE_URL: 'postgresql://source.url',
-          RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS: 'false',
+          BACKUP_MODE: 'true',
         };
 
         // when

--- a/test/unit/steps_test.js
+++ b/test/unit/steps_test.js
@@ -23,7 +23,7 @@ describe('Unit | steps.js', () => {
       // given
       const configuration = {
         SOURCE_DATABASE_URL: 'postgresql://source.url',
-        BACKUP_MODE: 'false',
+        BACKUP_MODE: {},
       };
 
       // when
@@ -55,7 +55,7 @@ describe('Unit | steps.js', () => {
         // given
         const configuration = {
           SOURCE_DATABASE_URL: 'postgresql://source.url',
-          BACKUP_MODE: 'true',
+          BACKUP_MODE: { 'knowledge-elements': 'incremental', 'knowledge-element-snapshots': 'incremental', 'answers': 'incremental' },
         };
 
         // when


### PR DESCRIPTION
## :unicorn: Problème
Les tables a répliquer incrémentallement est spécifié dans le code. Il est donc indispensable de faire un MEP pour modifier le comportement.

## :robot: Solution
Utiliser une variable d'environnement pour mettre à jour la liste des tables qui ne sont pas répliqué via WAL.
Elles seront soit 
- répliqué incrémentallement, via le mode `incremental`
- pas répliqué, via le mode `none`
`BACKUP_MODE= {"answers":"none", "knowledge-elements":"none","knowledge-element-snapshots":"incremental"}`
On aura ici la table `knowledge-elements-snapshots` répliquée en incrémentale alors que les tables `answers` et `knowledge-elements` ne seront pas répliquées.

## :rainbow: Remarques
Il reste une partie "statique" pour _l'enrichment_ qui permet de créer des vues/index après la réplication. Le systeme permet tout de même de ne pas créé ces vues/index si les tables concernés sont en backup "none" ou "incrémental"

## :100: Pour tester
Supprimer les var env `RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS` et `RESTORE_ANSWERS_AND_KES_AND_KE_SNAPSHOTS_INCREMENTALLY` 
Ajouter `BACKUP_MODE` avec les valeurs souhaiter et verifier que la réplication correspond à l'attendu
