### PR TITLE
[BUGFIX] Exclure des tables lors de la réplication complète.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Dans certains cas, le besoin est de relancer uniquement les opérations de fin d
 
 ##### Import AirTable
 ``` bash
-node -e "steps=require('./src/steps'); steps.importAirtableData(require ('./src/extract-configuration-from-environment')())"
+node -e "steps=require('./src/steps'); steps.importAirtableData(require ('./src/config/extract-configuration-from-environment')())"
 ```
 
 ##### Enrichissement
@@ -123,7 +123,7 @@ RESTORE_FK_CONSTRAINTS=true
 
 Lancer la réplication
 ``` bash
-node -e "steps=require('./src/steps'); steps.fullReplicationAndEnrichment(require ('./src/extract-configuration-from-environment')())"
+node -e "steps=require('./src/steps'); steps.fullReplicationAndEnrichment(require ('./src/config/sextract-configuration-from-environment')())"
 ```
 
 Au bout de 5 minutes, vous devez obtenir le message
@@ -179,7 +179,7 @@ node -e "steps=require('./src/steps'); steps.importAirtableData(require ('./src/
 ##### Enrichissement
 Création index, vues..
 ``` bash
-node -e "steps=require('./src/steps'); steps.addEnrichment(require ('./src/extract-configuration-from-environment')())"
+node -e "steps=require('./src/steps'); steps.addEnrichment(require ('./src/config/extract-configuration-from-environment')())"
 ```
 
 

--- a/src/replicate-incrementally.js
+++ b/src/replicate-incrementally.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const execa = require('execa');
-const { getIncrementalTables } = require('./steps');
+const { getTablesWithReplicationModes, REPLICATION_MODE } = require('./steps');
 
 const logger = require('./logger');
 
@@ -15,7 +15,7 @@ function escapeSQLIdentifier(identifier) {
 }
 
 async function run(configuration) {
-  const incrementalTables = getIncrementalTables(configuration);
+  const incrementalTables = getTablesWithReplicationModes(configuration, [REPLICATION_MODE.INCREMENTAL]);
   if (incrementalTables.length === 0) {
     logger.info('Exit because BACKUP_MODE is not incremental');
     return;

--- a/src/replication_job.js
+++ b/src/replication_job.js
@@ -105,7 +105,7 @@ function _addQueueEventsListeners(queue) {
 }
 
 function hasIncremental(configuration) {
-  const incrementalTables = steps.getIncrementalTables(configuration);
+  const incrementalTables = steps.getTablesWithReplicationModes(configuration, [steps.REPLICATION_MODE.INCREMENTAL]);
   return incrementalTables.length > 0;
 }
 

--- a/test/unit/steps_test.js
+++ b/test/unit/steps_test.js
@@ -86,6 +86,42 @@ describe('Unit | steps.js', () => {
       });
     });
 
+    context('when anwers, knowledge elements and knowledge element snapshots are not restored', () => {
+      it('should not backup answers, knowledge-elements and knowledge-element-snapshots tables', async () => {
+        // given
+        const configuration = {
+          SOURCE_DATABASE_URL: 'postgresql://source.url',
+          BACKUP_MODE: { 'knowledge-elements': 'none', 'knowledge-element-snapshots': 'none', 'answers': 'none' },
+        };
+
+        // when
+        await createBackup(configuration);
+
+        // then
+        expect(execStub).to.have.been.calledWith(
+          'pg_dump',
+          [
+            '--clean',
+            '--if-exists',
+            '--format', 'c',
+            '--dbname', 'postgresql://source.url',
+            '--no-owner',
+            '--no-privileges',
+            '--no-comments',
+            '--exclude-schema',
+            'information_schema',
+            '--exclude-schema', '\'^pg_*\'',
+            '--file', './dump.pgsql',
+            '--exclude-table', 'knowledge-elements',
+            '--exclude-table', 'knowledge-element-snapshots',
+            '--exclude-table', 'answers',
+          ],
+          { stdio: 'inherit' },
+        );
+
+      });
+    });
+
   });
 
 });


### PR DESCRIPTION
## :unicorn: Problème
Après l'externalisation de la configuration des tables de réplication avec les modes none et incremental:
`BACKUP_MODE={"answers":"none","knowledge-elements":"none","knowledge-element-snapshots":"incremental"}
`
On peut faire une réplication incrémentale unitaire par table avec le mode incremental. 
Néanmoins, lorsque la config de la table est positionné à **none**, la création du backup ne l'ignore pas, ce qui rallonge le temps et fait échouer la réplication en full-backup en production.

## :robot: Solution
Ignorer la création du backup et sa restauration pour le mode réplication "none".

## :rainbow: Remarques
Des tests ont été enrichis pour gérer ce cas.

## :100: Pour tester
Tester en locale.
Tester avec succès en production pour la source de donnée externe.