### PR TITLE
[TECH] Utiliser la bonne colonne airtable pour le nom des compétences.

### DIFF
--- a/src/airtable-data.js
+++ b/src/airtable-data.js
@@ -31,7 +31,7 @@ const tables = [{
   fields: [
     { name: 'name', type: 'text', airtableName: 'Référence' },
     { name: 'code', type: 'text', airtableName: 'Sous-domaine' },
-    { name: 'title', type: 'text', airtableName: 'Titre' },
+    { name: 'title', type: 'text', airtableName: 'Titre fr-fr' },
     { name: 'origin', type: 'text', airtableName: 'Origine' },
     { name: 'areaId', type: 'text', airtableName: 'Domaine (id persistant)', isArray: false },
   ],


### PR DESCRIPTION
## :unicorn: Problème
La réplication utilisait une ancienne colonne pour renseigner le nom d'une compétence.

## :robot: Solution
Utiliser la nouvelle colonne ``Titre fr-fr`` au lieu de la colonne ``Titre``. 

## :rainbow: Remarques
RAS

## :100: Pour tester
RAS
