### PR TITLE
[TECH] Monter les BDD de développement en version majeure 13.3 depuis la 12.4.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
   test:
     docker:
       - image: cimg/node:14.15.4
-      - image: postgres:12.4-alpine
+      - image: postgres:13.3-alpine
         environment:
           POSTGRES_USER: postgres
           POSTGRES_HOST_AUTH_METHOD: trust
@@ -72,13 +72,29 @@ jobs:
           paths:
             - ~/.npm
       - run :
+          name : Add PG13 package key
+          command: |
+            wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+      - run :
+          name : Add PG13 package
+          command:
+            echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
+      - run :
           name : Refresh package cache
           command: |
-            sudo apt-get update
+            sudo apt update
       - run :
-          name : Install psql
+          name : Install PG13 client package
           command: |
-            sudo apt-get install postgresql-client-12
+            sudo apt install postgresql-client-13
+      - run :
+          name : Checking pg_dump version
+          command: |
+            pg_dump --version
+      - run :
+          name : Checking pg_restore version
+          command: |
+            pg_restore --version
       - run:
           name: Waiting for PostgreSQL to start
           command: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   database:
     container_name: database
-    image: postgres:12.4-alpine
+    image: postgres:13.3-alpine
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
     restart: unless-stopped


### PR DESCRIPTION
## :unicorn: Problème
Une nouvelle version majeure de PostgreSQL (13.3) est disponible sur Scalingo.
Elle est utilisée automatiquement en review app.

Les BDD de développement n'utilisent pas cette version et des comportements inexpliqués peuvent apparaître en:
- local;
- CI;
- production (le jour où la BDD source de la réplication sera en PG13).

## :robot: Solution
Aligner les BDD de développement avec la version majeure.

Si la CI est lancée avec uniquement le changement d'image PG, elle sort en erreur
``` bash
pg_dump: error: server version: 13.3; pg_dump version: 12.8 (Ubuntu 12.8-0ubuntu0.20.04.1)
pg_dump: error: aborting because of server version mismatch
```

Les image de [node CircleCI](https://circleci.com/developer/images/image/cimg/node) se basent sur ubuntu 20, et le client pg 13 n'est pas embarqué nativement avant ubuntu 21.

Il nous faut donc installer le paquetage client PG 13 (dont fait partie `pg_dump`) manuellement dans la CI en [modifiant les sources d'origine package](https://computingforgeeks.com/how-to-install-postgresql-13-on-ubuntu/) pour ajouter ceux de PG.

## :rainbow: Remarques
Changelogs:
- [13](https://www.postgresql.org/docs/13/release-13.html)
- [13.1](https://www.postgresql.org/docs/release/13.1/)
- [13.2](https://www.postgresql.org/docs/release/13.2/)
- [13.3](https://www.postgresql.org/docs/release/13.3/)

Après merge, sur les applications Scalingo 
- intégration
- production 

Effectuer les action suivantes:
 - modifier la variable d'environnement `PG_CLIENT_VERSION` à `13`
 - monter manuellent la version (resources)

Il serait intéressant d'avoir en test (CI) le même OS que sur le run (Scalingo)
```
[07:45][osc-secnum-fr1] Scalingo:pix-datawarehouse-production ~ $ cat /etc/*-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=18.04
DISTRIB_CODENAME=bionic
DISTRIB_DESCRIPTION="Ubuntu 18.04.6 LTS"
NAME="Ubuntu"
VERSION="18.04.6 LTS (Bionic Beaver)"
```

## :100: Pour tester
Vérifier que la suite de test passe en CI et en local

Sur la review app, lancer une réplication depuis une base 13.3 (ici: `pix-datawarehouse-api`)

Créer un utrilisateur dans la base cible
```bash
scalingo --region osc-fr1 --app pix-datawarehouse-api  pgsql-console
```

```sql
-- psql (PostgreSQL) 13.3
-- (..)
INSERT INTO users ( "firstName", "lastName")
VALUES ('John', 'Doe');
SELECT * FROM users ORDER BY id DESC;
```

Paramétrez une réplication complète en modifiant la variable d'environnement de `pix-datawarehouse-integration-pr102`
`BACKUP_MODE={}`

Lancez la réplication
`scalingo run --region osc-fr1 --app pix-datawarehouse-integration-pr102  --size M --detached npm run restart:full-replication`

Vérifiez le message suivant dans les logs
```bash
scalingo --region osc-fr1 --app pix-datawarehouse-integration-pr102 logs --lines 10000 | grep "End restore Backup"
2021-10-14 14:01:27.638019655 +0200 CEST[background-1] {"name":"pix-datawarehouse-integration-pr102","hostname":"pix-datawarehouse-integration-pr102-background-1","pid":20,"level":30,"msg":"End restore Backup","time":"2021-10-14T12:01:27.637Z","v":0} 
```

Vérifiez que vous retrouvez cet utilisateur
``` bash
scalingo --region osc-fr1 --app pix-datawarehouse-integration-pr102  pgsql-console
```

```sql
-- psql (PostgreSQL) 13.3
SELECT * FROM users ORDER BY id DESC;
```

