### PR TITLE
[TECH] Formater le code avec Prettier.

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,4 +1,6 @@
-extends: 'eslint:recommended'
+extends:
+  - 'eslint:recommended'
+  - 'plugin:prettier/recommended'
 
 overrides:
   - files:

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "printWidth": 120,
+  "singleQuote": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,22 +44,49 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.2.tgz",
-      "integrity": "sha512-EfB5OHNYp1F4px/LI/FEnGylop7nOqkQ1LRzCM0KccA2U8tvV8w01KBv37LbO7nW4H+YhKyo2LcJhRwjjV17QQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.3.tgz",
+      "integrity": "sha512-DHI1wDPoKCBPoLZA3qDR91+3te/wDSc1YhKg3jR8NxKKRJq2hwHwcWv31cSwSYvIBrmbENoYMWcenW8uproQqg==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
-        "debug": "^4.1.1",
-        "espree": "^7.3.0",
-        "globals": "^12.1.0",
+        "debug": "^4.3.2",
+        "espree": "^9.0.0",
+        "globals": "^13.9.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.19",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
       }
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.6.0.tgz",
+      "integrity": "sha512-JQlEKbcgEUjBFhLIF4iqM7u/9lwgHRBcpHrmUNCALK0Q3amXN6lxdoXLnF0sm11E9VqTmBALR87IlUg1bZ8A9A==",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.0",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
+      "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+      "dev": true
     },
     "@sentry/core": {
       "version": "6.1.0",
@@ -201,15 +228,15 @@
       "integrity": "sha512-O6Xk757Jb4o0LMzMOMdWvxpHWrQzruYBaUruFaIOfAQRnWFxfdXYobw12jrVHGtoXk6WiiyYzc0QWN9aL62HQA=="
     },
     "acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+      "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true
     },
     "agent-base": {
@@ -291,12 +318,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
-    },
-    "astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
     "balanced-match": {
@@ -813,9 +834,9 @@
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
     "define-properties": {
@@ -909,12 +930,6 @@
         "nan": "^2.14.0"
       }
     },
-    "emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
-    },
     "enquirer": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
@@ -978,49 +993,131 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.17.0.tgz",
-      "integrity": "sha512-zJk08MiBgwuGoxes5sSQhOtibZ75pz0J35XTRlZOk9xMffhpA9BTbQZxoXZzOl5zMbleShbGwtw+1kGferfFwQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.0.1.tgz",
+      "integrity": "sha512-LsgcwZgQ72vZ+SMp4K6pAnk2yFDWL7Ti4pJaRvsZ0Hsw2h8ZjUIW38a9AFn2cZXdBMlScMFYYgsSp4ttFI/0bA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@eslint/eslintrc": "^0.2.2",
+        "@eslint/eslintrc": "^1.0.3",
+        "@humanwhocodes/config-array": "^0.6.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
-        "debug": "^4.0.1",
+        "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "enquirer": "^2.3.5",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^2.1.0",
-        "eslint-visitor-keys": "^2.0.0",
-        "espree": "^7.3.1",
-        "esquery": "^1.2.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^6.0.0",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.0.0",
+        "espree": "^9.0.0",
+        "esquery": "^1.4.0",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^6.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^5.0.0",
-        "globals": "^12.1.0",
+        "glob-parent": "^6.0.1",
+        "globals": "^13.6.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
-        "js-yaml": "^3.13.1",
+        "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.19",
+        "lodash.merge": "^4.6.2",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
         "progress": "^2.0.0",
-        "regexpp": "^3.1.0",
+        "regexpp": "^3.2.0",
         "semver": "^7.2.1",
         "strip-ansi": "^6.0.0",
         "strip-json-comments": "^3.1.0",
-        "table": "^6.0.4",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "eslint-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^2.0.0"
+          },
+          "dependencies": {
+            "eslint-visitor-keys": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+              "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+              "dev": true
+            }
+          }
+        },
+        "glob-parent": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.3"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+              "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.1"
+              }
+            }
+          }
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "regexpp": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+          "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+          "dev": true
+        }
       }
+    },
+    "eslint-config-prettier": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+      "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
+      "dev": true
     },
     "eslint-plugin-es": {
       "version": "3.0.1",
@@ -1070,6 +1167,15 @@
         }
       }
     },
+    "eslint-plugin-prettier": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
+      "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
     "eslint-plugin-yaml": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-yaml/-/eslint-plugin-yaml-0.3.0.tgz",
@@ -1081,13 +1187,13 @@
       }
     },
     "eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-6.0.0.tgz",
+      "integrity": "sha512-uRDL9MWmQCkaFus8RF5K9/L/2fn+80yoW3jkD53l4shjCh26fCtvJGasxjUqP5OT87SYTxCVA3BwTUzuELx9kA==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
+        "estraverse": "^5.2.0"
       }
     },
     "eslint-utils": {
@@ -1108,28 +1214,20 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
-      "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz",
+      "integrity": "sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==",
       "dev": true
     },
     "espree": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
-      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.0.0.tgz",
+      "integrity": "sha512-r5EQJcYZ2oaGbeR0jR0fFVijGOcwai07/690YRXLINuhmVeRY4UKSAsQPe/0BNuDgwP7Ophoc1PRsr2E3tkbdQ==",
       "dev": true,
       "requires": {
-        "acorn": "^7.4.0",
+        "acorn": "^8.5.0",
         "acorn-jsx": "^5.3.1",
-        "eslint-visitor-keys": "^1.3.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
-        }
+        "eslint-visitor-keys": "^3.0.0"
       }
     },
     "esprima": {
@@ -1139,20 +1237,12 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
-      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
-          "dev": true
-        }
       }
     },
     "esrecurse": {
@@ -1162,20 +1252,12 @@
       "dev": true,
       "requires": {
         "estraverse": "^5.2.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
-          "dev": true
-        }
       }
     },
     "estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+      "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
       "dev": true
     },
     "esutils": {
@@ -1217,6 +1299,12 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -1230,9 +1318,9 @@
       "dev": true
     },
     "file-entry-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.0.tgz",
-      "integrity": "sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
       "requires": {
         "flat-cache": "^3.0.4"
@@ -1293,9 +1381,9 @@
       }
     },
     "flatted": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.0.tgz",
-      "integrity": "sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
+      "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
     },
     "for-each": {
@@ -1385,12 +1473,12 @@
       }
     },
     "globals": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
+      "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
       "dev": true,
       "requires": {
-        "type-fest": "^0.8.1"
+        "type-fest": "^0.20.2"
       }
     },
     "graceful-fs": {
@@ -1564,12 +1652,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
-    },
-    "is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true
     },
     "is-glob": {
@@ -1768,6 +1850,12 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
     "lodash.set": {
@@ -2329,6 +2417,21 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
+    "prettier": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
+    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -2437,12 +2540,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-    },
-    "require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true
     },
     "require-main-filename": {
       "version": "2.0.0",
@@ -2584,43 +2681,6 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
-    "slice-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        }
-      }
-    },
     "split2": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
@@ -2659,17 +2719,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.0.1.tgz",
       "integrity": "sha512-NQOxSeB8gOI5WjSaxjBgog2QFw55FV8TkS6Y07BiB3VJ8xNTvUYm0wl0s8ObgQ5NhdpnNfigMIKjgPESzgr4tg=="
-    },
-    "string-width": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-      "dev": true,
-      "requires": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
-      }
     },
     "string.prototype.trimend": {
       "version": "1.0.3",
@@ -2720,38 +2769,6 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
         "has-flag": "^3.0.0"
-      }
-    },
-    "table": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.0.7.tgz",
-      "integrity": "sha512-rxZevLGTUzWna/qBLObOe16kB2RTnnbhciwgPbMMlazz1yZGVEgnZK762xyVdVznhqxrfCeBMmMkgOOaPwjH7g==",
-      "dev": true,
-      "requires": {
-        "ajv": "^7.0.2",
-        "lodash": "^4.17.20",
-        "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.3.tgz",
-          "integrity": "sha512-R50QRlXSxqXcQP5SvKUrw8VZeypvo12i2IX0EeR5PiZ7bEKeHWgzgo264LDadUsCU42lTJVhFikTqJwNeH34gQ==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
-        }
       }
     },
     "table-layout": {
@@ -2830,9 +2847,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
     },
     "typical": {
@@ -2846,9 +2863,9 @@
       "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
     },
     "uri-js": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
@@ -2877,9 +2894,9 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
-      "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -48,14 +48,17 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^7.17.0",
+    "eslint": "^8.0.1",
+    "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-mocha": "^8.0.0",
     "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-yaml": "^0.3.0",
     "husky": "^4.3.7",
     "mocha": "^8.2.1",
     "nock": "^13.0.5",
     "pg-connection-string": "^2.4.0",
+    "prettier": "^2.4.1",
     "proxyquire": "^2.1.3",
     "sinon": "^9.2.3",
     "tmp-promise": "^3.0.2"

--- a/src/airtable-data.js
+++ b/src/airtable-data.js
@@ -5,121 +5,139 @@ const _ = require('lodash');
 const format = require('pg-format');
 const { runDBOperation } = require('./db-connection');
 
-const tables = [{
-  name: 'areas',
-  airtableName: 'Domaines',
-  fields: [
-    { name: 'name', type: 'text', airtableName: 'Nom' },
-  ],
-  airtableId: 'id persistant',
-  indices: [],
-}, {
-  name: 'attachments',
-  airtableName: 'Attachments',
-  fields: [
-    { name: 'type', type: 'text', airtableName: 'type' },
-    { name: 'challengeId', type: 'text', airtableName: 'challengeId persistant' },
-    { name: 'alt', type: 'text', airtableName: 'alt' },
-    { name: 'url', type: 'text', airtableName: 'url' },
-    { name: 'size', type: 'numeric', airtableName: 'size' },
-  ],
-  airtableId: 'Record ID',
-  indices: [],
-}, {
-  name: 'competences',
-  airtableName: 'Competences',
-  fields: [
-    { name: 'name', type: 'text', airtableName: 'Référence' },
-    { name: 'code', type: 'text', airtableName: 'Sous-domaine' },
-    { name: 'title', type: 'text', airtableName: 'Titre fr-fr' },
-    { name: 'origin', type: 'text', airtableName: 'Origine' },
-    { name: 'areaId', type: 'text', airtableName: 'Domaine (id persistant)', isArray: false },
-  ],
-  airtableId: 'id persistant',
-  indices: ['areaId'],
-}, {
-  name: 'tubes',
-  airtableName: 'Tubes',
-  fields: [
-    { name: 'name', type: 'text', airtableName: 'Nom' },
-    { name: 'title', type: 'text', airtableName: 'Titre' },
-    { name: 'competenceId', type: 'text', airtableName: 'Competences (id persistant)', isArray: false },
-  ],
-  airtableId: 'id persistant',
-  indices: ['competenceId'],
-}, {
-  name: 'skills',
-  airtableName: 'Acquis',
-  fields: [
-    { name: 'name', type: 'text', airtableName: 'Nom' },
-    { name: 'description', type: 'text', airtableName: 'Description' },
-    { name: 'level', type: 'smallint', airtableName: 'Level' },
-    { name: 'tubeId', type: 'text', airtableName: 'Tube (id persistant)', isArray: false },
-    { name: 'status', type: 'text', airtableName: 'Status' },
-    { name: 'pixValue', type: 'numeric(6,5)', airtableName: 'PixValue' },
-    { name: 'hintStatus', type: 'text', airtableName: 'Statut de l\'indice' },
-    { name: 'tutorialIds', type: 'text []', airtableName: 'Comprendre (id persistant)', isArray: true },
-    { name: 'learningMoreTutorialIds', type: 'text []', airtableName: 'En savoir plus (id persistant)', isArray: true },
-    { name: 'internationalization', type: 'text', airtableName: 'Internationalisation' },
-  ],
-  airtableId: 'id persistant',
-  indices: ['tubeId'],
-}, {
-  name: 'challenges',
-  airtableName: 'Epreuves',
-  fields: [
-    { name: 'instructions', type: 'text', airtableName: 'Consigne' },
-    { name: 'status', type: 'text', airtableName: 'Statut' },
-    { name: 'type', type: 'text', airtableName: 'Type d\'épreuve' },
-    { name: 'timer', type: 'smallint', airtableName: 'Timer' },
-    { name: 'autoReply', type: 'boolean', airtableName: 'Réponse automatique' },
-    { name: 'skillIds', type: 'text []', airtableName: 'Acquix (id persistant)', isArray: true },
-    { name: 'skillCount', type: 'smallint', extractor: (record) => _.size(record.get('Acquix (id persistant)')) },
-    { name: 'firstSkillId', type: 'text', extractor: (record) => _.get(record.get('Acquix (id persistant)'), 0) },
-    { name: 'secondSkillId', type: 'text', extractor: (record) => _.get(record.get('Acquix (id persistant)'), 1) },
-    { name: 'thirdSkillId', type: 'text', extractor: (record) => _.get(record.get('Acquix (id persistant)'), 2) },
-    { name: 'languages', type: 'text []', airtableName: 'Langues', isArray: true },
-    { name: 'embedUrl', type: 'text', airtableName: 'Embed URL' },
-    { name: 'hasEmbedUrl', type: 'boolean', extractor: (record) => !!record.get('Embed URL') },
-    { name: 'alternativeInstruction', type: 'text', airtableName: 'Consigne alternative' },
-    { name: 'hasAlternativeInstruction', type: 'boolean', extractor: (record) => !!record.get('Consigne alternative') },
-    { name: 'area', type: 'text', airtableName: 'Géographie' },
-    { name: 'focus', type: 'boolean', airtableName: 'Focalisée' },
-    { name: 'explicativeResponse', type: 'text', airtableName: 'Bonnes réponses à afficher' },
-  ],
-  airtableId: 'id persistant',
-  indices: ['firstSkillId'],
-}, {
-  name: 'courses',
-  airtableName: 'Tests',
-  fields: [
-    { name: 'name', type: 'text', airtableName: 'Nom' },
-    { name: 'adaptive', type: 'boolean', airtableName: 'Adaptatif ?' },
-    { name: 'competenceId', type: 'text', airtableName: 'Competence (id persistant)', isArray: false },
-  ],
-  airtableId: 'id persistant',
-  indices: ['competenceId'],
-}, {
-  name: 'tutorials',
-  airtableName: 'Tutoriels',
-  fields: [
-    { name: 'title', type: 'text', airtableName: 'Titre' },
-    { name: 'link', type: 'text', airtableName: 'Lien' },
-    { name: 'tutorialForSkills', type: 'text []', airtableName: 'Solution à', isArray: true },
-    { name: 'furtherInformation', type: 'text []', airtableName: 'En savoir plus', isArray: true },
-    { name: 'locale', type: 'text', airtableName: 'Langue' },
-  ],
-  airtableId: 'id persistant',
-  indices: ['title'],
-}];
+const tables = [
+  {
+    name: 'areas',
+    airtableName: 'Domaines',
+    fields: [{ name: 'name', type: 'text', airtableName: 'Nom' }],
+    airtableId: 'id persistant',
+    indices: [],
+  },
+  {
+    name: 'attachments',
+    airtableName: 'Attachments',
+    fields: [
+      { name: 'type', type: 'text', airtableName: 'type' },
+      { name: 'challengeId', type: 'text', airtableName: 'challengeId persistant' },
+      { name: 'alt', type: 'text', airtableName: 'alt' },
+      { name: 'url', type: 'text', airtableName: 'url' },
+      { name: 'size', type: 'numeric', airtableName: 'size' },
+    ],
+    airtableId: 'Record ID',
+    indices: [],
+  },
+  {
+    name: 'competences',
+    airtableName: 'Competences',
+    fields: [
+      { name: 'name', type: 'text', airtableName: 'Référence' },
+      { name: 'code', type: 'text', airtableName: 'Sous-domaine' },
+      { name: 'title', type: 'text', airtableName: 'Titre fr-fr' },
+      { name: 'origin', type: 'text', airtableName: 'Origine' },
+      { name: 'areaId', type: 'text', airtableName: 'Domaine (id persistant)', isArray: false },
+    ],
+    airtableId: 'id persistant',
+    indices: ['areaId'],
+  },
+  {
+    name: 'tubes',
+    airtableName: 'Tubes',
+    fields: [
+      { name: 'name', type: 'text', airtableName: 'Nom' },
+      { name: 'title', type: 'text', airtableName: 'Titre' },
+      { name: 'competenceId', type: 'text', airtableName: 'Competences (id persistant)', isArray: false },
+    ],
+    airtableId: 'id persistant',
+    indices: ['competenceId'],
+  },
+  {
+    name: 'skills',
+    airtableName: 'Acquis',
+    fields: [
+      { name: 'name', type: 'text', airtableName: 'Nom' },
+      { name: 'description', type: 'text', airtableName: 'Description' },
+      { name: 'level', type: 'smallint', airtableName: 'Level' },
+      { name: 'tubeId', type: 'text', airtableName: 'Tube (id persistant)', isArray: false },
+      { name: 'status', type: 'text', airtableName: 'Status' },
+      { name: 'pixValue', type: 'numeric(6,5)', airtableName: 'PixValue' },
+      { name: 'hintStatus', type: 'text', airtableName: 'Statut de l\'indice' },
+      { name: 'tutorialIds', type: 'text []', airtableName: 'Comprendre (id persistant)', isArray: true },
+      {
+        name: 'learningMoreTutorialIds',
+        type: 'text []',
+        airtableName: 'En savoir plus (id persistant)',
+        isArray: true,
+      },
+      { name: 'internationalization', type: 'text', airtableName: 'Internationalisation' },
+    ],
+    airtableId: 'id persistant',
+    indices: ['tubeId'],
+  },
+  {
+    name: 'challenges',
+    airtableName: 'Epreuves',
+    fields: [
+      { name: 'instructions', type: 'text', airtableName: 'Consigne' },
+      { name: 'status', type: 'text', airtableName: 'Statut' },
+      { name: 'type', type: 'text', airtableName: 'Type d\'épreuve' },
+      { name: 'timer', type: 'smallint', airtableName: 'Timer' },
+      { name: 'autoReply', type: 'boolean', airtableName: 'Réponse automatique' },
+      { name: 'skillIds', type: 'text []', airtableName: 'Acquix (id persistant)', isArray: true },
+      { name: 'skillCount', type: 'smallint', extractor: (record) => _.size(record.get('Acquix (id persistant)')) },
+      { name: 'firstSkillId', type: 'text', extractor: (record) => _.get(record.get('Acquix (id persistant)'), 0) },
+      { name: 'secondSkillId', type: 'text', extractor: (record) => _.get(record.get('Acquix (id persistant)'), 1) },
+      { name: 'thirdSkillId', type: 'text', extractor: (record) => _.get(record.get('Acquix (id persistant)'), 2) },
+      { name: 'languages', type: 'text []', airtableName: 'Langues', isArray: true },
+      { name: 'embedUrl', type: 'text', airtableName: 'Embed URL' },
+      { name: 'hasEmbedUrl', type: 'boolean', extractor: (record) => !!record.get('Embed URL') },
+      { name: 'alternativeInstruction', type: 'text', airtableName: 'Consigne alternative' },
+      {
+        name: 'hasAlternativeInstruction',
+        type: 'boolean',
+        extractor: (record) => !!record.get('Consigne alternative'),
+      },
+      { name: 'area', type: 'text', airtableName: 'Géographie' },
+      { name: 'focus', type: 'boolean', airtableName: 'Focalisée' },
+      { name: 'explicativeResponse', type: 'text', airtableName: 'Bonnes réponses à afficher' },
+    ],
+    airtableId: 'id persistant',
+    indices: ['firstSkillId'],
+  },
+  {
+    name: 'courses',
+    airtableName: 'Tests',
+    fields: [
+      { name: 'name', type: 'text', airtableName: 'Nom' },
+      { name: 'adaptive', type: 'boolean', airtableName: 'Adaptatif ?' },
+      { name: 'competenceId', type: 'text', airtableName: 'Competence (id persistant)', isArray: false },
+    ],
+    airtableId: 'id persistant',
+    indices: ['competenceId'],
+  },
+  {
+    name: 'tutorials',
+    airtableName: 'Tutoriels',
+    fields: [
+      { name: 'title', type: 'text', airtableName: 'Titre' },
+      { name: 'link', type: 'text', airtableName: 'Lien' },
+      { name: 'tutorialForSkills', type: 'text []', airtableName: 'Solution à', isArray: true },
+      { name: 'furtherInformation', type: 'text []', airtableName: 'En savoir plus', isArray: true },
+      { name: 'locale', type: 'text', airtableName: 'Langue' },
+    ],
+    airtableId: 'id persistant',
+    indices: ['title'],
+  },
+];
 
 async function fetchAndSaveData(configuration) {
-  await Promise.all(tables.map(async (table) => {
-    const data = await _getItems(table, configuration);
-    await _dropTable(table.name, configuration);
-    await _createTable(table, configuration);
-    await _saveItems(table, data, configuration);
-  }));
+  await Promise.all(
+    tables.map(async (table) => {
+      const data = await _getItems(table, configuration);
+      await _dropTable(table.name, configuration);
+      await _createTable(table, configuration);
+      await _saveItems(table, data, configuration);
+    }),
+  );
 }
 
 async function _dropTable(tableName, configuration) {
@@ -131,9 +149,13 @@ async function _dropTable(tableName, configuration) {
 
 async function _createTable(table, configuration) {
   await runDBOperation(async (client) => {
-    const fieldsText = ['"id" text PRIMARY KEY'].concat(table.fields.map((field) => {
-      return format('\t%I\t%s', field.name, field.type + (field.type === 'boolean' ? ' NOT NULL' : ''));
-    })).join(',\n');
+    const fieldsText = ['"id" text PRIMARY KEY']
+      .concat(
+        table.fields.map((field) => {
+          return format('\t%I\t%s', field.name, field.type + (field.type === 'boolean' ? ' NOT NULL' : ''));
+        }),
+      )
+      .join(',\n');
     const createQuery = format('CREATE TABLE %I (%s)', table.name, fieldsText);
     await client.query(createQuery);
     for (const index of table.indices) {
@@ -165,9 +187,11 @@ async function _getItems(structure, configuration) {
   if (structure.airtableId) {
     airtableFields.push(structure.airtableId);
   }
-  const records = await base(structure.airtableName).select({
-    fields: airtableFields,
-  }).all();
+  const records = await base(structure.airtableName)
+    .select({
+      fields: airtableFields,
+    })
+    .all();
   return records.map((record) => {
     const item = { id: record.get(structure.airtableId) || record.getId() };
     fields.forEach((field) => {

--- a/src/enrichment.js
+++ b/src/enrichment.js
@@ -9,15 +9,17 @@ async function add(configuration) {
     const tablesToNotBeEnriched = _getTablesToNotBeEnriched(configuration);
     if (!tablesToNotBeEnriched.includes('knowledge-elements')) {
       logger.info('CREATE INDEX "knowledge-elements_createdAt_idx" - Started');
-      await client.query('CREATE INDEX "knowledge-elements_createdAt_idx" on "knowledge-elements" (cast("createdAt" AT TIME ZONE \'UTC+1\' as date) DESC)');
+      await client.query(
+        'CREATE INDEX "knowledge-elements_createdAt_idx" on "knowledge-elements" (cast("createdAt" AT TIME ZONE \'UTC+1\' as date) DESC)',
+      );
       logger.info('CREATE INDEX "knowledge-elements_createdAt_idx" - Ended');
-
     }
     if (!tablesToNotBeEnriched.includes('knowledge-element-snapshots')) {
       logger.info('CREATE INDEX "knowledge-element-snapshots_snappedAt_idx" - Started');
-      await client.query('CREATE INDEX "knowledge-element-snapshots_snappedAt_idx" on "knowledge-element-snapshots" (cast("snappedAt" AT TIME ZONE \'UTC+1\' as date) DESC)');
+      await client.query(
+        'CREATE INDEX "knowledge-element-snapshots_snappedAt_idx" on "knowledge-element-snapshots" (cast("snappedAt" AT TIME ZONE \'UTC+1\' as date) DESC)',
+      );
       logger.info('CREATE INDEX "knowledge-element-snapshots_snappedAt_idx" - Ended');
-
     }
     if (!tablesToNotBeEnriched.includes('answers')) {
       logger.info('CREATE INDEX "answers_challengeId_idx" - Started');
@@ -27,7 +29,9 @@ async function add(configuration) {
 
     if (!tablesToNotBeEnriched.includes('users')) {
       logger.info('CREATE INDEX "users_createdAt_idx" - Started');
-      await client.query('CREATE INDEX "users_createdAt_idx" on "users" (cast("createdAt" AT TIME ZONE \'UTC+1\' as date) DESC)');
+      await client.query(
+        'CREATE INDEX "users_createdAt_idx" on "users" (cast("createdAt" AT TIME ZONE \'UTC+1\' as date) DESC)',
+      );
       logger.info('CREATE INDEX "users_createdAt_idx" - Ended');
     }
     if (!tablesToNotBeEnriched.includes('schooling-registrations')) {
@@ -40,9 +44,7 @@ async function add(configuration) {
 
 function _getTablesToNotBeEnriched(configuration) {
   const tablePairs = toPairs(configuration.BACKUP_MODE);
-  return tablePairs
-    .filter(([_, mode]) => mode === 'incremental' || mode === 'none')
-    .map(([tableName, _]) => tableName);
+  return tablePairs.filter(([_, mode]) => mode === 'incremental' || mode === 'none').map(([tableName, _]) => tableName);
 }
 
 module.exports = {

--- a/src/replicate-incrementally.js
+++ b/src/replicate-incrementally.js
@@ -38,7 +38,6 @@ async function run(configuration) {
       name: table,
       lastRecordIndex: lastRecordIndexTargetBeforeReplication,
     });
-
   }
 
   logger.info('Start COPY FROM/TO through STDIN/OUT');
@@ -55,7 +54,9 @@ async function run(configuration) {
       `\\copy ${escapeSQLIdentifier(table.name)} from stdin`,
     ];
     const copyToStdOutProcess = execa('psql', copyToStdOutArgs, {
-      stdin: 'ignore', stdout: 'pipe', stderr: 'inherit',
+      stdin: 'ignore',
+      stdout: 'pipe',
+      stderr: 'inherit',
       buffer: false, // disable execa's buffering otherwise it interferes with the transfer
     });
     const copyFromStdInProcess = execa('psql', copyFromStdInArgs, {
@@ -63,7 +64,7 @@ async function run(configuration) {
       all: true, // join stdout and stderr
     });
 
-    const [ , copyFromStdInResult ] = await Promise.all([ copyToStdOutProcess, copyFromStdInProcess ]);
+    const [, copyFromStdInResult] = await Promise.all([copyToStdOutProcess, copyFromStdInProcess]);
 
     logger.info(`${table.name} table copy returned: ` + copyFromStdInResult.all);
 

--- a/src/replication_job.js
+++ b/src/replication_job.js
@@ -11,12 +11,11 @@ const replicationQueue = _createQueue('Replication queue');
 const airtableReplicationQueue = _createQueue('Airtable replication queue');
 const incrementalReplicationQueue = _createQueue('Incremental replication queue');
 
-main()
-  .catch(async (error) => {
-    Sentry.captureException(error);
-    logger.error(error);
-    await _flushSentryAndExit();
-  });
+main().catch(async (error) => {
+  Sentry.captureException(error);
+  logger.error(error);
+  await _flushSentryAndExit();
+});
 
 async function main() {
   initSentry(configuration);
@@ -55,7 +54,6 @@ async function _setInterruptedJobsAsFailed() {
     if (activeJobs.length === 0) {
       logger.info(`No active jobs to be marked as failed for queue ${queue.name}`);
     }
-
   });
   return Promise.all(promises);
 }
@@ -100,7 +98,9 @@ function _addQueueEventsListeners(queue) {
       logger.info(`Completed job in ${queue.name}: ${job.id}`);
     })
     .on('failed', function(job, err) {
-      logger.error(`Failed job in ${queue.name}: ${job.id} ${err} (Number of attempts: ${job.attemptsMade}/${job.opts.attempts})`);
+      logger.error(
+        `Failed job in ${queue.name}: ${job.id} ${err} (Number of attempts: ${job.attemptsMade}/${job.opts.attempts})`,
+      );
     });
 }
 

--- a/src/run-replicate-incrementally.js
+++ b/src/run-replicate-incrementally.js
@@ -11,13 +11,12 @@ async function main() {
   await runner.run(configuration);
 }
 
-main()
-  .catch(async (error) => {
-    logger.error(error);
-    Sentry.captureException(error);
-    await Sentry.close(2000);
-    process.exit(1);
-  });
+main().catch(async (error) => {
+  logger.error(error);
+  Sentry.captureException(error);
+  await Sentry.close(2000);
+  process.exit(1);
+});
 
 async function exitOnSignal(signal) {
   logger.info(`Received signal ${signal}.`);
@@ -25,10 +24,16 @@ async function exitOnSignal(signal) {
   process.exit(1);
 }
 
-process.on('uncaughtException', () => { exitOnSignal('uncaughtException'); });
+process.on('uncaughtException', () => {
+  exitOnSignal('uncaughtException');
+});
 process.on('unhandledRejection', (reason, promise) => {
   logger.info('Unhandled Rejection at:', promise, 'reason:', reason);
   exitOnSignal('unhandledRejection');
 });
-process.on('SIGTERM', () => { exitOnSignal('SIGTERM'); });
-process.on('SIGINT', () => { exitOnSignal('SIGINT'); });
+process.on('SIGTERM', () => {
+  exitOnSignal('SIGTERM');
+});
+process.on('SIGINT', () => {
+  exitOnSignal('SIGINT');
+});

--- a/src/run.js
+++ b/src/run.js
@@ -10,7 +10,6 @@ const { configuration } = require('./config');
 const TIMEOUT = 2000;
 
 async function main() {
-
   try {
     initSentry(configuration);
 
@@ -41,12 +40,18 @@ async function flushSentryAndExit(exitCode) {
   process.exit(exitCode);
 }
 
-process.on('uncaughtException', () => { exitOnSignal('uncaughtException'); });
+process.on('uncaughtException', () => {
+  exitOnSignal('uncaughtException');
+});
 
 process.on('unhandledRejection', (reason, promise) => {
   logger.info('Unhandled Rejection at:', promise, 'reason:', reason);
   exitOnSignal('unhandledRejection');
 });
 
-process.on('SIGTERM', () => { exitOnSignal('SIGTERM'); });
-process.on('SIGINT', () => { exitOnSignal('SIGINT'); });
+process.on('SIGTERM', () => {
+  exitOnSignal('SIGTERM');
+});
+process.on('SIGINT', () => {
+  exitOnSignal('SIGINT');
+});

--- a/src/schedule-incremental-replication.js
+++ b/src/schedule-incremental-replication.js
@@ -8,15 +8,20 @@ const initSentry = require('./sentry-init');
 
 const { configuration } = require('./config');
 
-new CronJob(configuration.SCHEDULE, async function() {
-  try {
-    initSentry(configuration);
-    await replicateIncrementally.run(configuration);
-  } catch (error) {
-    logger.error(error);
-    Sentry.captureException(error);
-    await Sentry.close(2000);
-    process.exit(1);
-  }
-}, null, true, parisTimezone);
-
+new CronJob(
+  configuration.SCHEDULE,
+  async function() {
+    try {
+      initSentry(configuration);
+      await replicateIncrementally.run(configuration);
+    } catch (error) {
+      logger.error(error);
+      Sentry.captureException(error);
+      await Sentry.close(2000);
+      process.exit(1);
+    }
+  },
+  null,
+  true,
+  parisTimezone,
+);

--- a/src/sentry-init.js
+++ b/src/sentry-init.js
@@ -13,7 +13,7 @@ const initSentry = function(configuration) {
   Sentry.init({
     enabled: isFeatureEnabled(configuration.SENTRY_ENABLED),
     dsn: configuration.SENTRY_DSN,
-    environment: (configuration.SENTRY_ENVIRONMENT || 'development'),
+    environment: configuration.SENTRY_ENVIRONMENT || 'development',
     maxBreadcrumbs: _getNumber(configuration.SENTRY_MAX_BREADCRUMBS, 100),
     debug: isFeatureEnabled(configuration.SENTRY_DEBUG),
     maxValueLength: configuration.SENTRY_MAX_VALUE_LENGTH || 1000,

--- a/test/acceptance/full-dump-replication-test.js
+++ b/test/acceptance/full-dump-replication-test.js
@@ -11,7 +11,6 @@ async function getCountFromTable({ targetDatabase, tableName }) {
 }
 
 describe('Acceptance | steps | fullReplicationAndEnrichment', () => {
-
   // CircleCI set up environment variables to access DB, so we need to read them here
   // eslint-disable-next-line no-process-env
   const SOURCE_DATABASE_URL = process.env.SOURCE_DATABASE_URL || 'postgres://pix@localhost:5432/replication_source';
@@ -73,25 +72,36 @@ describe('Acceptance | steps | fullReplicationAndEnrichment', () => {
   });
 
   describe('should import database data', () => {
-
     it('should replicate answers and knowledge-elements and knowledge-element-snapshots', async () => {
       // then
       const restoredRowCount = await getCountFromTable({ targetDatabase, tableName: targetDatabaseConfig.tableName });
 
       expect(restoredRowCount).to.equal(targetDatabaseConfig.tableRowCount);
 
-      const isAnswersRestored = parseInt(await targetDatabase.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'answers\''));
+      const isAnswersRestored = parseInt(
+        await targetDatabase.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'answers\''),
+      );
       expect(isAnswersRestored).to.equal(1);
 
       // then
-      const isKnowledgeElementsRestored = parseInt(await targetDatabase.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-elements\''));
+      const isKnowledgeElementsRestored = parseInt(
+        await targetDatabase.runSql(
+          'SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-elements\''
+        ),
+      );
       expect(isKnowledgeElementsRestored).to.equal(1);
 
       // then
-      const isKnowledgeElementSnapshotsRestored = parseInt(await targetDatabase.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-element-snapshots\''));
+      const isKnowledgeElementSnapshotsRestored = parseInt(
+        await targetDatabase.runSql(
+          'SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-element-snapshots\''
+        ),
+      );
       expect(isKnowledgeElementSnapshotsRestored).to.equal(1);
 
-      const indexCount = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'users_createdAt_idx\''));
+      const indexCount = parseInt(
+        await targetDatabase.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'users_createdAt_idx\''),
+      );
       expect(indexCount).to.equal(1);
     });
   });
@@ -143,31 +153,44 @@ describe('Acceptance | steps | fullReplicationAndEnrichment', () => {
   });
 
   describe('should enrich imported data', () => {
-
     it('should create indexes', async function() {
       // then
-      const indexCount = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'users_createdAt_idx\''));
+      const indexCount = parseInt(
+        await targetDatabase.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'users_createdAt_idx\''),
+      );
       expect(indexCount).to.equal(1);
 
       // then
-      const KEIndexCount = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'knowledge-elements_createdAt_idx\''));
+      const KEIndexCount = parseInt(
+        await targetDatabase.runSql(
+          'SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'knowledge-elements_createdAt_idx\''
+        ),
+      );
       expect(KEIndexCount).to.equal(1);
 
       // then
-      const KESnapshotsIndexCount = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'knowledge-element-snapshots_snappedAt_idx\''));
+      const KESnapshotsIndexCount = parseInt(
+        await targetDatabase.runSql(
+          'SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'knowledge-element-snapshots_snappedAt_idx\''
+        ),
+      );
       expect(KESnapshotsIndexCount).to.equal(1);
 
       // then
-      const answersIndexCount = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'answers_challengeId_idx\''));
+      const answersIndexCount = parseInt(
+        await targetDatabase.runSql(
+          'SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'answers_challengeId_idx\''
+        ),
+      );
       expect(answersIndexCount).to.equal(1);
-
     });
 
     it('should create view students', async function() {
       // then
-      const viewCount = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM pg_views vws WHERE vws.viewname = \'students\';'));
+      const viewCount = parseInt(
+        await targetDatabase.runSql('SELECT COUNT(1) FROM pg_views vws WHERE vws.viewname = \'students\';'),
+      );
       expect(viewCount).to.equal(1);
     });
   });
-
 });

--- a/test/integration/enrichment_test.js
+++ b/test/integration/enrichment_test.js
@@ -11,7 +11,6 @@ const Database = require('../utils/database');
 const { add } = require('../../src/enrichment');
 
 describe('Integration | enrichment.js', () => {
-
   const config = pgUrlParser(DATABASE_URL);
 
   const databaseConfig = {
@@ -24,7 +23,6 @@ describe('Integration | enrichment.js', () => {
   databaseConfig.databaseUrl = `${databaseConfig.serverUrl}/${databaseConfig.databaseName}`;
 
   describe('add', function() {
-
     context('according to environment variables', () => {
       let database;
 
@@ -37,19 +35,19 @@ describe('Integration | enrichment.js', () => {
           mode: 'none',
           itLabel: 'should not create indexes for tables on "none" mode',
           tables: ['knowledge-elements', 'knowledge-element-snapshots', 'answers', 'users', 'schooling-registrations'],
-          'indexCount': 0,
+          indexCount: 0,
         },
         {
           mode: 'incremental',
           itLabel: 'should not create indexes for tables on "incremental" mode',
           tables: ['knowledge-elements', 'knowledge-element-snapshots', 'answers', 'users', 'schooling-registrations'],
-          'indexCount': 0,
+          indexCount: 0,
         },
         {
           mode: '',
           itLabel: 'should create indexes for tables not specified in var env',
           tables: [],
-          'indexCount': 1,
+          indexCount: 1,
         },
       ].forEach(({ mode, itLabel, tables, indexCount }) =>
         it(itLabel, async function() {
@@ -58,30 +56,43 @@ describe('Integration | enrichment.js', () => {
           await createAndFillDatabase(database, databaseConfig, { createTablesNotToBeImported: true });
 
           // when
-          const BACKUP_MODE = tables.reduce((tablesObject, tableName) =>
-            ({ ...tablesObject, [tableName]: mode }), {});
+          const BACKUP_MODE = tables.reduce((tablesObject, tableName) => ({ ...tablesObject, [tableName]: mode }), {});
           const configuration = { BACKUP_MODE, DATABASE_URL: databaseConfig.databaseUrl };
           await add(configuration);
 
           // then
-          const KEIndexCount = parseInt(await database.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'knowledge-elements_createdAt_idx\''));
+          const KEIndexCount = parseInt(
+            await database.runSql(
+              'SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'knowledge-elements_createdAt_idx\''
+            ),
+          );
           expect(KEIndexCount).to.equal(indexCount);
 
           // then
-          const KESnapshotsIndexCount = parseInt(await database.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'knowledge-element-snapshots_snappedAt_idx\''));
+          const KESnapshotsIndexCount = parseInt(
+            await database.runSql(
+              'SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'knowledge-element-snapshots_snappedAt_idx\''
+            ),
+          );
           expect(KESnapshotsIndexCount).to.equal(indexCount);
 
           // then
-          const answersIndexCount = parseInt(await database.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'answers_challengeId_idx\''));
+          const answersIndexCount = parseInt(
+            await database.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'answers_challengeId_idx\''),
+          );
           expect(answersIndexCount).to.equal(indexCount);
 
-          const usersIndexCount = parseInt(await database.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'users_createdAt_idx\''));
+          const usersIndexCount = parseInt(
+            await database.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'users_createdAt_idx\''),
+          );
           expect(usersIndexCount).to.equal(indexCount);
 
-          const viewCount = parseInt(await database.runSql('SELECT COUNT(1) FROM pg_views vws WHERE vws.viewname = \'students\';'));
+          const viewCount = parseInt(
+            await database.runSql('SELECT COUNT(1) FROM pg_views vws WHERE vws.viewname = \'students\';'),
+          );
           expect(viewCount).to.equal(indexCount);
-        }));
+        }),
+      );
     });
   });
-
 });

--- a/test/integration/replicate-incrementally-test.js
+++ b/test/integration/replicate-incrementally-test.js
@@ -9,9 +9,7 @@ const steps = require('../../src/steps');
 const { run } = require('../../src/replicate-incrementally');
 
 describe('Integration | replicate-incrementally.js', () => {
-
   describe('run', function() {
-
     // CircleCI set up environment variables to access DB, so we need to read them here
     // eslint-disable-next-line no-process-env
     const SOURCE_DATABASE_URL = process.env.SOURCE_DATABASE_URL || 'postgres://pix@localhost:5432/replication_source';
@@ -23,8 +21,7 @@ describe('Integration | replicate-incrementally.js', () => {
     let sourceDatabaseConfig;
     let targetDatabaseConfig;
 
-    before(async() => {
-
+    before(async () => {
       const rawSourceDataBaseConfig = pgUrlParser(SOURCE_DATABASE_URL);
 
       sourceDatabaseConfig = {
@@ -46,34 +43,36 @@ describe('Integration | replicate-incrementally.js', () => {
       };
 
       targetDatabaseConfig.databaseUrl = `${targetDatabaseConfig.serverUrl}/${targetDatabaseConfig.databaseName}`;
-
     });
 
     context('when incremental restore is disabled', () => {
-
       it('should not copy any values', async function() {
-
         // given
         targetDatabase = await Database.create(targetDatabaseConfig);
         await createAndFillDatabase(targetDatabase, targetDatabaseConfig, { createTablesNotToBeImported: true });
-        const knowledgeElementsCountBefore = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM "knowledge-elements"'));
+        const knowledgeElementsCountBefore = parseInt(
+          await targetDatabase.runSql('SELECT COUNT(1) FROM "knowledge-elements"'),
+        );
         expect(knowledgeElementsCountBefore).not.to.equal(0);
 
-        const configuration = { SOURCE_DATABASE_URL: SOURCE_DATABASE_URL, TARGET_DATABASE_URL: TARGET_DATABASE_URL, PG_RESTORE_JOBS: 4 };
+        const configuration = {
+          SOURCE_DATABASE_URL: SOURCE_DATABASE_URL,
+          TARGET_DATABASE_URL: TARGET_DATABASE_URL,
+          PG_RESTORE_JOBS: 4,
+        };
 
         // when
         await run(configuration);
 
         // then
-        const knowledgeElementsCountAfter = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM "knowledge-elements"'));
+        const knowledgeElementsCountAfter = parseInt(
+          await targetDatabase.runSql('SELECT COUNT(1) FROM "knowledge-elements"'),
+        );
         expect(knowledgeElementsCountAfter).to.equal(knowledgeElementsCountBefore);
-
       });
-
     });
 
     context('when incremental restore is enabled', () => {
-
       [
         {
           name: 'answers',
@@ -89,17 +88,26 @@ describe('Integration | replicate-incrementally.js', () => {
         },
       ].forEach(({ name, errorMessage }) => {
         it(`should throw if table ${name} is empty`, async function() {
-
           // given
 
           sourceDatabase = await Database.create(sourceDatabaseConfig);
-          const backupFile = await createBackup(sourceDatabase, sourceDatabaseConfig, { createTablesNotToBeImported: true });
+          const backupFile = await createBackup(sourceDatabase, sourceDatabaseConfig, {
+            createTablesNotToBeImported: true,
+          });
 
           targetDatabase = await Database.create(targetDatabaseConfig);
 
           // TODO: do not use production code to setup environment
-          const firstDayConfiguration = { BACKUP_MODE: { [name]: 'none' }, RESTORE_FK_CONSTRAINTS: 'false', PG_RESTORE_JOBS: 4 };
-          await steps.restoreBackup({ backupFile, databaseUrl: targetDatabaseConfig.databaseUrl, configuration: firstDayConfiguration });
+          const firstDayConfiguration = {
+            BACKUP_MODE: { [name]: 'none' },
+            RESTORE_FK_CONSTRAINTS: 'false',
+            PG_RESTORE_JOBS: 4,
+          };
+          await steps.restoreBackup({
+            backupFile,
+            databaseUrl: targetDatabaseConfig.databaseUrl,
+            configuration: firstDayConfiguration,
+          });
 
           // Day 2
 
@@ -111,10 +119,12 @@ describe('Integration | replicate-incrementally.js', () => {
           await createAndFillDatabase(targetDatabase, targetDatabaseConfig, { createTablesNotToBeImported: true });
           await targetDatabase.runSql(`DELETE FROM "${name}"`);
 
-          const configuration = { SOURCE_DATABASE_URL: SOURCE_DATABASE_URL,
+          const configuration = {
+            SOURCE_DATABASE_URL: SOURCE_DATABASE_URL,
             TARGET_DATABASE_URL: TARGET_DATABASE_URL,
             BACKUP_MODE: { [name]: 'incremental' },
-            PG_RESTORE_JOBS: 4 };
+            PG_RESTORE_JOBS: 4,
+          };
 
           // when
           const promise = run(configuration);
@@ -125,26 +135,35 @@ describe('Integration | replicate-incrementally.js', () => {
       });
 
       it('should copy all missing values', async function() {
-
         // given
 
         // Day 1
         sourceDatabase = await Database.create(sourceDatabaseConfig);
-        const backupFile = await createBackup(sourceDatabase, sourceDatabaseConfig, { createTablesNotToBeImported: true });
+        const backupFile = await createBackup(sourceDatabase, sourceDatabaseConfig, {
+          createTablesNotToBeImported: true,
+        });
 
         targetDatabase = await Database.create(targetDatabaseConfig);
 
         // TODO: do not use production code to setup environment
         const firstDayConfiguration = { BACKUP_MODE: {}, RESTORE_FK_CONSTRAINTS: 'false', PG_RESTORE_JOBS: 4 };
-        await steps.restoreBackup({ backupFile, databaseUrl: targetDatabaseConfig.databaseUrl, configuration: firstDayConfiguration });
+        await steps.restoreBackup({
+          backupFile,
+          databaseUrl: targetDatabaseConfig.databaseUrl,
+          configuration: firstDayConfiguration,
+        });
 
         const answersCountBefore = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM answers'));
         expect(answersCountBefore).not.to.equal(0);
 
-        const knowledgeElementsCountBefore = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM "knowledge-elements"'));
+        const knowledgeElementsCountBefore = parseInt(
+          await targetDatabase.runSql('SELECT COUNT(1) FROM "knowledge-elements"'),
+        );
         expect(knowledgeElementsCountBefore).not.to.equal(0);
 
-        const knowledgeElementSnapshotCountBefore = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM "knowledge-element-snapshots"'));
+        const knowledgeElementSnapshotCountBefore = parseInt(
+          await targetDatabase.runSql('SELECT COUNT(1) FROM "knowledge-element-snapshots"'),
+        );
         expect(knowledgeElementSnapshotCountBefore).not.to.equal(0);
 
         // Day 2
@@ -154,15 +173,29 @@ describe('Integration | replicate-incrementally.js', () => {
         await createAndFillDatabase(sourceDatabase, sourceDatabaseConfig, { createTablesNotToBeImported: true });
         await sourceDatabase.runSql('INSERT INTO answers (id, "challengeId") VALUES (2,2)');
         await sourceDatabase.runSql('INSERT INTO answers (id, "challengeId") VALUES (3,2)');
-        await sourceDatabase.runSql('INSERT INTO "knowledge-elements"  (id, "userId", "createdAt") VALUES (2, 2, CURRENT_TIMESTAMP)');
-        await sourceDatabase.runSql('INSERT INTO "knowledge-elements"  (id, "userId", "createdAt") VALUES (3, 2, CURRENT_TIMESTAMP)');
-        await sourceDatabase.runSql('INSERT INTO "knowledge-element-snapshots"  (id, "userId", "snappedAt", "snapshot") VALUES (2, 2, CURRENT_TIMESTAMP, \'{"id": "3"}\'::jsonb)');
-        await sourceDatabase.runSql('INSERT INTO "knowledge-element-snapshots"  (id, "userId", "snappedAt", "snapshot") VALUES (3, 2, CURRENT_TIMESTAMP, \'{"id": "3"}\'::jsonb)');
+        await sourceDatabase.runSql(
+          'INSERT INTO "knowledge-elements"  (id, "userId", "createdAt") VALUES (2, 2, CURRENT_TIMESTAMP)',
+        );
+        await sourceDatabase.runSql(
+          'INSERT INTO "knowledge-elements"  (id, "userId", "createdAt") VALUES (3, 2, CURRENT_TIMESTAMP)',
+        );
+        await sourceDatabase.runSql(
+          'INSERT INTO "knowledge-element-snapshots"  (id, "userId", "snappedAt", "snapshot") VALUES (2, 2, CURRENT_TIMESTAMP, \'{"id": "3"}\'::jsonb)',
+        );
+        await sourceDatabase.runSql(
+          'INSERT INTO "knowledge-element-snapshots"  (id, "userId", "snappedAt", "snapshot") VALUES (3, 2, CURRENT_TIMESTAMP, \'{"id": "3"}\'::jsonb)',
+        );
 
         // given
         const configuration = {
-          BACKUP_MODE: { 'knowledge-elements': 'incremental', 'knowledge-element-snapshots': 'incremental', 'answers': 'incremental' },
-          SOURCE_DATABASE_URL: SOURCE_DATABASE_URL, TARGET_DATABASE_URL: TARGET_DATABASE_URL, PG_RESTORE_JOBS: 4,
+          BACKUP_MODE: {
+            'knowledge-elements': 'incremental',
+            'knowledge-element-snapshots': 'incremental',
+            answers: 'incremental',
+          },
+          SOURCE_DATABASE_URL: SOURCE_DATABASE_URL,
+          TARGET_DATABASE_URL: TARGET_DATABASE_URL,
+          PG_RESTORE_JOBS: 4,
         };
 
         // when
@@ -179,14 +212,13 @@ describe('Integration | replicate-incrementally.js', () => {
         expect(knowledgeElementsCountAfter).to.equal(knowledgeElementsCountBefore + 2);
 
         // then
-        const knowledgeElementSnpashotCount = await targetDatabase.runSql('SELECT COUNT(1) FROM "knowledge-element-snapshots"');
+        const knowledgeElementSnpashotCount = await targetDatabase.runSql(
+          'SELECT COUNT(1) FROM "knowledge-element-snapshots"',
+        );
         const knowledgeElementSnpashotCountfter = parseInt(knowledgeElementSnpashotCount);
         expect(knowledgeElementSnpashotCountfter).to.equal(knowledgeElementSnapshotCountBefore + 2);
         // TODO: check the rows copied have matching IDs
-
       });
-
     });
-
   });
 });

--- a/test/integration/steps_test.js
+++ b/test/integration/steps_test.js
@@ -7,7 +7,6 @@ const fs = require('fs');
 const steps = require('../../src/steps');
 
 describe('Integration | steps.js', () => {
-
   describe('#backupAndRestore', () => {
     // CircleCI set up environment variables to access DB, so we need to read them here
     // eslint-disable-next-line no-process-env
@@ -19,7 +18,7 @@ describe('Integration | steps.js', () => {
     let sourceDatabaseConfig;
     let targetDatabaseConfig;
 
-    before(async() => {
+    before(async () => {
       const rawSourceDataBaseConfig = pgUrlParser(SOURCE_DATABASE_URL);
 
       sourceDatabaseConfig = {
@@ -41,7 +40,6 @@ describe('Integration | steps.js', () => {
       };
 
       targetDatabaseConfig.databaseUrl = `${targetDatabaseConfig.serverUrl}/${targetDatabaseConfig.databaseName}`;
-
     });
 
     afterEach(async function() {
@@ -50,7 +48,6 @@ describe('Integration | steps.js', () => {
     });
 
     context('when configuration mention tables in incremental backup mode', () => {
-
       it('should backup and restore the database without answers, knowledge-elements & knowledge-element-snapshots', async () => {
         // given
         const configuration = {
@@ -60,7 +57,7 @@ describe('Integration | steps.js', () => {
           BACKUP_MODE: {
             'knowledge-elements': 'incremental',
             'knowledge-element-snapshots': 'incremental',
-            'answers': 'incremental',
+            answers: 'incremental',
           },
           PG_RESTORE_JOBS: 1,
         };
@@ -72,25 +69,37 @@ describe('Integration | steps.js', () => {
         await steps.backupAndRestore(configuration);
 
         // then
-        const restoredRowCount = parseInt(await targetDatabase.runSql(`SELECT COUNT(*) FROM ${targetDatabaseConfig.tableName}`));
+        const restoredRowCount = parseInt(
+          await targetDatabase.runSql(`SELECT COUNT(*) FROM ${targetDatabaseConfig.tableName}`),
+        );
         expect(restoredRowCount).to.equal(targetDatabaseConfig.tableRowCount);
 
-        const isAnswersRestored = parseInt(await targetDatabase.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'answers\''));
+        const isAnswersRestored = parseInt(
+          await targetDatabase.runSql(
+            'SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'answers\''
+          ),
+        );
         expect(isAnswersRestored).to.equal(0);
 
         // then
-        const isKnowledgeElementsRestored = parseInt(await targetDatabase.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-elements\''));
+        const isKnowledgeElementsRestored = parseInt(
+          await targetDatabase.runSql(
+            'SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-elements\''
+          ),
+        );
         expect(isKnowledgeElementsRestored).to.equal(0);
 
         // then
-        const isKnowledgeElementSnapshotsRestored = parseInt(await targetDatabase.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-element-snapshots\''));
+        const isKnowledgeElementSnapshotsRestored = parseInt(
+          await targetDatabase.runSql(
+            'SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-element-snapshots\''
+          ),
+        );
         expect(isKnowledgeElementSnapshotsRestored).to.equal(0);
       });
-
     });
 
     context('when configuration exclude tables', () => {
-
       it('should backup and restore the database without answers, knowledge-elements & knowledge-element-snapshots', async () => {
         // given
         const configuration = {
@@ -100,7 +109,7 @@ describe('Integration | steps.js', () => {
           BACKUP_MODE: {
             'knowledge-elements': 'none',
             'knowledge-element-snapshots': 'none',
-            'answers': 'none',
+            answers: 'none',
           },
           PG_RESTORE_JOBS: 1,
         };
@@ -112,25 +121,37 @@ describe('Integration | steps.js', () => {
         await steps.backupAndRestore(configuration);
 
         // then
-        const restoredRowCount = parseInt(await targetDatabase.runSql(`SELECT COUNT(*) FROM ${targetDatabaseConfig.tableName}`));
+        const restoredRowCount = parseInt(
+          await targetDatabase.runSql(`SELECT COUNT(*) FROM ${targetDatabaseConfig.tableName}`),
+        );
         expect(restoredRowCount).to.equal(targetDatabaseConfig.tableRowCount);
 
-        const isAnswersRestored = parseInt(await targetDatabase.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'answers\''));
+        const isAnswersRestored = parseInt(
+          await targetDatabase.runSql(
+            'SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'answers\''
+          ),
+        );
         expect(isAnswersRestored).to.equal(0);
 
         // then
-        const isKnowledgeElementsRestored = parseInt(await targetDatabase.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-elements\''));
+        const isKnowledgeElementsRestored = parseInt(
+          await targetDatabase.runSql(
+            'SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-elements\''
+          ),
+        );
         expect(isKnowledgeElementsRestored).to.equal(0);
 
         // then
-        const isKnowledgeElementSnapshotsRestored = parseInt(await targetDatabase.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-element-snapshots\''));
+        const isKnowledgeElementSnapshotsRestored = parseInt(
+          await targetDatabase.runSql(
+            'SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-element-snapshots\''
+          ),
+        );
         expect(isKnowledgeElementSnapshotsRestored).to.equal(0);
       });
-
     });
 
     context('When backup config table is not present', () => {
-
       it('should backup and restore the database with answers, knowledge-elements & knowledge-element-snapshots', async () => {
         // given
         const configuration = {
@@ -148,27 +169,38 @@ describe('Integration | steps.js', () => {
         await steps.backupAndRestore(configuration);
 
         // then
-        const restoredRowCount = parseInt(await targetDatabase.runSql(`SELECT COUNT(*) FROM ${targetDatabaseConfig.tableName}`));
+        const restoredRowCount = parseInt(
+          await targetDatabase.runSql(`SELECT COUNT(*) FROM ${targetDatabaseConfig.tableName}`),
+        );
         expect(restoredRowCount).to.equal(targetDatabaseConfig.tableRowCount);
 
-        const isAnswersRestored = parseInt(await targetDatabase.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'answers\''));
+        const isAnswersRestored = parseInt(
+          await targetDatabase.runSql(
+            'SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'answers\''
+          ),
+        );
         expect(isAnswersRestored).to.equal(1);
 
         // then
-        const isKnowledgeElementsRestored = parseInt(await targetDatabase.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-elements\''));
+        const isKnowledgeElementsRestored = parseInt(
+          await targetDatabase.runSql(
+            'SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-elements\''
+          ),
+        );
         expect(isKnowledgeElementsRestored).to.equal(1);
 
         // then
-        const isKnowledgeElementSnapshotsRestored = parseInt(await targetDatabase.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-element-snapshots\''));
+        const isKnowledgeElementSnapshotsRestored = parseInt(
+          await targetDatabase.runSql(
+            'SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-element-snapshots\''
+          ),
+        );
         expect(isKnowledgeElementSnapshotsRestored).to.equal(1);
       });
-
     });
-
   });
 
   describe('#restoreBackup', () => {
-
     // CircleCI set up environment variables to access DB, so we need to read them here
     // eslint-disable-next-line no-process-env
     const DATABASE_URL = process.env.TARGET_DATABASE_URL || 'postgres://postgres@localhost:5432/replication_target';
@@ -184,7 +216,6 @@ describe('Integration | steps.js', () => {
     databaseConfig.databaseUrl = `${databaseConfig.serverUrl}/${databaseConfig.databaseName}`;
 
     context('whatever options are provided', () => {
-
       let database;
 
       afterEach(() => {
@@ -206,18 +237,16 @@ describe('Integration | steps.js', () => {
         expect(restoredRowCount).to.equal(databaseConfig.tableRowCount);
 
         // then
-        const restoredComment = await database.runSql(`SELECT obj_description('${databaseConfig.tableName}'::regclass, 'pg_class')`);
+        const restoredComment = await database.runSql(
+          `SELECT obj_description('${databaseConfig.tableName}'::regclass, 'pg_class')`,
+        );
         expect(restoredComment).to.be.empty;
       });
-
     });
 
     context('according to environment variables', () => {
-
       context('table restoration', () => {
-
         context('with incremental mode', () => {
-
           let database;
 
           afterEach(() => {
@@ -225,15 +254,16 @@ describe('Integration | steps.js', () => {
           });
 
           it('should not restore these tables', async function() {
-
             // given
             database = await Database.create(databaseConfig);
-            const backupFile = await createBackupAndCreateEmptyDatabase(database, databaseConfig, { createTablesNotToBeImported: true });
+            const backupFile = await createBackupAndCreateEmptyDatabase(database, databaseConfig, {
+              createTablesNotToBeImported: true,
+            });
             const configuration = {
               BACKUP_MODE: {
                 'knowledge-elements': 'incremental',
                 'knowledge-element-snapshots': 'incremental',
-                'answers': 'incremental',
+                answers: 'incremental',
               },
               RESTORE_FK_CONSTRAINTS: 'false',
               PG_RESTORE_JOBS: 4,
@@ -243,23 +273,30 @@ describe('Integration | steps.js', () => {
             await steps.restoreBackup({ backupFile, databaseUrl: databaseConfig.databaseUrl, configuration });
 
             // then
-            const isAnswersRestored = parseInt(await database.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'answers\''));
+            const isAnswersRestored = parseInt(
+              await database.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'answers\''),
+            );
             expect(isAnswersRestored).to.equal(0);
 
             // then
-            const isKnowledgeElementsRestored = parseInt(await database.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-elements\''));
+            const isKnowledgeElementsRestored = parseInt(
+              await database.runSql(
+                'SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-elements\''
+              ),
+            );
             expect(isKnowledgeElementsRestored).to.equal(0);
 
             // then
-            const isKnowledgeElementSnapshotsRestored = parseInt(await database.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-element-snapshots\''));
+            const isKnowledgeElementSnapshotsRestored = parseInt(
+              await database.runSql(
+                'SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-element-snapshots\''
+              ),
+            );
             expect(isKnowledgeElementSnapshotsRestored).to.equal(0);
-
           });
-
         });
 
         context('with none mode', () => {
-
           let database;
 
           afterEach(() => {
@@ -267,15 +304,16 @@ describe('Integration | steps.js', () => {
           });
 
           it('should not restore these tables', async function() {
-
             // given
             database = await Database.create(databaseConfig);
-            const backupFile = await createBackupAndCreateEmptyDatabase(database, databaseConfig, { createTablesNotToBeImported: true });
+            const backupFile = await createBackupAndCreateEmptyDatabase(database, databaseConfig, {
+              createTablesNotToBeImported: true,
+            });
             const configuration = {
               BACKUP_MODE: {
                 'knowledge-elements': 'incremental',
                 'knowledge-element-snapshots': 'incremental',
-                'answers': 'incremental',
+                answers: 'incremental',
               },
               RESTORE_FK_CONSTRAINTS: 'false',
               PG_RESTORE_JOBS: 4,
@@ -285,23 +323,30 @@ describe('Integration | steps.js', () => {
             await steps.restoreBackup({ backupFile, databaseUrl: databaseConfig.databaseUrl, configuration });
 
             // then
-            const isAnswersRestored = parseInt(await database.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'answers\''));
+            const isAnswersRestored = parseInt(
+              await database.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'answers\''),
+            );
             expect(isAnswersRestored).to.equal(0);
 
             // then
-            const isKnowledgeElementsRestored = parseInt(await database.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-elements\''));
+            const isKnowledgeElementsRestored = parseInt(
+              await database.runSql(
+                'SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-elements\''
+              ),
+            );
             expect(isKnowledgeElementsRestored).to.equal(0);
 
             // then
-            const isKnowledgeElementSnapshotsRestored = parseInt(await database.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-element-snapshots\''));
+            const isKnowledgeElementSnapshotsRestored = parseInt(
+              await database.runSql(
+                'SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-element-snapshots\''
+              ),
+            );
             expect(isKnowledgeElementSnapshotsRestored).to.equal(0);
-
           });
-
         });
 
         context('with default mode', () => {
-
           let database;
 
           afterEach(async function() {
@@ -309,10 +354,11 @@ describe('Integration | steps.js', () => {
           });
 
           it('does restore these tables', async function() {
-
             // given
             database = await Database.create(databaseConfig);
-            const backupFile = await createBackupAndCreateEmptyDatabase(database, databaseConfig, { createTablesNotToBeImported: true });
+            const backupFile = await createBackupAndCreateEmptyDatabase(database, databaseConfig, {
+              createTablesNotToBeImported: true,
+            });
             const configuration = {
               BACKUP_MODE: {},
               RESTORE_FK_CONSTRAINTS: 'false',
@@ -323,23 +369,31 @@ describe('Integration | steps.js', () => {
             await steps.restoreBackup({ backupFile, databaseUrl: databaseConfig.databaseUrl, configuration });
 
             // then
-            const isAnswersRestored = parseInt(await database.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'answers\''));
+            const isAnswersRestored = parseInt(
+              await database.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'answers\''),
+            );
             expect(isAnswersRestored).to.equal(1);
 
             // then
-            const isKnowledgeElementsRestored = parseInt(await database.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-elements\''));
+            const isKnowledgeElementsRestored = parseInt(
+              await database.runSql(
+                'SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-elements\''
+              ),
+            );
             expect(isKnowledgeElementsRestored).to.equal(1);
 
             // then
-            const isKnowledgeElementSnapshotsRestored = parseInt(await database.runSql('SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-element-snapshots\''));
+            const isKnowledgeElementSnapshotsRestored = parseInt(
+              await database.runSql(
+                'SELECT  COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'knowledge-element-snapshots\''
+              ),
+            );
             expect(isKnowledgeElementSnapshotsRestored).to.equal(1);
           });
-
         });
       });
 
       context('foreign key constraints', () => {
-
         context('if enabled', () => {
           let database;
 
@@ -348,20 +402,22 @@ describe('Integration | steps.js', () => {
           });
 
           it('should restore these constraints', async function() {
-
             // given
             database = await Database.create(databaseConfig);
-            const backupFile = await createBackupAndCreateEmptyDatabase(database, databaseConfig, { createForeignKeys: true });
+            const backupFile = await createBackupAndCreateEmptyDatabase(database, databaseConfig, {
+              createForeignKeys: true,
+            });
             const configuration = { RESTORE_FK_CONSTRAINTS: 'true', PG_RESTORE_JOBS: 4 };
 
             // when
             await steps.restoreBackup({ backupFile, databaseUrl: databaseConfig.databaseUrl, configuration });
 
             // then
-            const areForeignKeysRestored = parseInt(await database.runSql('SELECT COUNT(1) FROM pg_constraint pgc  WHERE pgc.contype = \'f\''));
+            const areForeignKeysRestored = parseInt(
+              await database.runSql('SELECT COUNT(1) FROM pg_constraint pgc  WHERE pgc.contype = \'f\''),
+            );
             expect(areForeignKeysRestored).to.equal(1);
           });
-
         });
 
         context('if disabled', () => {
@@ -372,26 +428,30 @@ describe('Integration | steps.js', () => {
           });
 
           it('should not restore keys constraints', async function() {
-
             // given
             database = await Database.create(databaseConfig);
-            const backupFile = await createBackupAndCreateEmptyDatabase(database, databaseConfig, { createForeignKeys: true });
+            const backupFile = await createBackupAndCreateEmptyDatabase(database, databaseConfig, {
+              createForeignKeys: true,
+            });
             const configuration = { RESTORE_FK_CONSTRAINTS: 'false', PG_RESTORE_JOBS: 4 };
 
             // when
             await steps.restoreBackup({ backupFile, databaseUrl: databaseConfig.databaseUrl, configuration });
 
             // then
-            const areForeignKeysRestored = parseInt(await database.runSql('SELECT COUNT(1) FROM pg_constraint pgc  WHERE pgc.contype = \'f\''));
+            const areForeignKeysRestored = parseInt(
+              await database.runSql('SELECT COUNT(1) FROM pg_constraint pgc  WHERE pgc.contype = \'f\''),
+            );
             expect(areForeignKeysRestored).to.equal(0);
           });
 
           it('should restore referencing table with data', async function() {
-
             // given
             const configuration = { RESTORE_FK_CONSTRAINTS: 'false', PG_RESTORE_JOBS: 4 };
             database = await Database.create(databaseConfig);
-            const backupFile = await createBackupAndCreateEmptyDatabase(database, databaseConfig, { createForeignKeys: true });
+            const backupFile = await createBackupAndCreateEmptyDatabase(database, databaseConfig, {
+              createForeignKeys: true,
+            });
 
             // when
             await steps.restoreBackup({ backupFile, databaseUrl: databaseConfig.databaseUrl, configuration });
@@ -402,24 +462,24 @@ describe('Integration | steps.js', () => {
           });
 
           it('should restore referenced table with data', async function() {
-
             // given
             const configuration = { RESTORE_FK_CONSTRAINTS: 'false', PG_RESTORE_JOBS: 4 };
             database = await Database.create(databaseConfig);
-            const backupFile = await createBackupAndCreateEmptyDatabase(database, databaseConfig, { createForeignKeys: true });
+            const backupFile = await createBackupAndCreateEmptyDatabase(database, databaseConfig, {
+              createForeignKeys: true,
+            });
 
             // when
             await steps.restoreBackup({ backupFile, databaseUrl: databaseConfig.databaseUrl, configuration });
 
             // then
-            const isAnswersRestored = parseInt(await database.runSql(`SELECT COUNT(1) FROM ${databaseConfig.tableName} `));
+            const isAnswersRestored = parseInt(
+              await database.runSql(`SELECT COUNT(1) FROM ${databaseConfig.tableName} `),
+            );
             expect(isAnswersRestored).to.equal(databaseConfig.tableRowCount);
           });
-
         });
-
       });
-
     });
   });
 
@@ -429,8 +489,7 @@ describe('Integration | steps.js', () => {
     let sourceDatabaseConfig;
     let targetDatabaseConfig;
 
-    before(async() => {
-
+    before(async () => {
       // CircleCI set up environment variables to access DB, so we need to read them here
       // eslint-disable-next-line no-process-env
       const SOURCE_DATABASE_URL = process.env.SOURCE_DATABASE_URL || 'postgres://pix@localhost:5432/replication_source';
@@ -458,7 +517,6 @@ describe('Integration | steps.js', () => {
       };
 
       targetDatabaseConfig.databaseUrl = `${targetDatabaseConfig.serverUrl}/${targetDatabaseConfig.databaseName}`;
-
     });
 
     beforeEach(async () => {
@@ -466,13 +524,19 @@ describe('Integration | steps.js', () => {
       targetDatabase = await Database.create(targetDatabaseConfig);
     });
 
-    async function createBackUpFromSourceAndRestoreToTarget(sourceDatabase, sourceDatabaseConfig, targetDatabaseUrl, configuration) {
-      const backupFile = await createBackup(sourceDatabase, sourceDatabaseConfig, { createTablesNotToBeImported: true });
+    async function createBackUpFromSourceAndRestoreToTarget(
+      sourceDatabase,
+      sourceDatabaseConfig,
+      targetDatabaseUrl,
+      configuration,
+    ) {
+      const backupFile = await createBackup(sourceDatabase, sourceDatabaseConfig, {
+        createTablesNotToBeImported: true,
+      });
       await steps.restoreBackup({ backupFile, databaseUrl: targetDatabaseUrl, configuration });
     }
 
     context('On specific tables, when restore is done incrementally (and not by backup)', () => {
-
       it('should preserve data', async function() {
         // given
 
@@ -481,29 +545,40 @@ describe('Integration | steps.js', () => {
           BACKUP_MODE: {},
           PG_RESTORE_JOBS: 4,
         };
-        await createBackUpFromSourceAndRestoreToTarget(sourceDatabase, sourceDatabaseConfig, targetDatabaseConfig.databaseUrl, firstDayConfiguration);
+        await createBackUpFromSourceAndRestoreToTarget(
+          sourceDatabase,
+          sourceDatabaseConfig,
+          targetDatabaseConfig.databaseUrl,
+          firstDayConfiguration,
+        );
 
         const answersCountBefore = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM answers'));
         expect(answersCountBefore).not.to.equal(0);
 
-        const knowledgeElementsCountBefore = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM "knowledge-elements"'));
+        const knowledgeElementsCountBefore = parseInt(
+          await targetDatabase.runSql('SELECT COUNT(1) FROM "knowledge-elements"'),
+        );
         expect(knowledgeElementsCountBefore).not.to.equal(0);
 
-        const knowledgeElementSnapshotsCountBefore = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM "knowledge-element-snapshots"'));
+        const knowledgeElementSnapshotsCountBefore = parseInt(
+          await targetDatabase.runSql('SELECT COUNT(1) FROM "knowledge-element-snapshots"'),
+        );
         expect(knowledgeElementSnapshotsCountBefore).not.to.equal(0);
 
         await sourceDatabase.dropDatabase();
 
         // Day 2
         await sourceDatabase.createDatabase();
-        const secondDayBackupFile = await createBackup(sourceDatabase, sourceDatabaseConfig, { createTablesNotToBeImported: true });
+        const secondDayBackupFile = await createBackup(sourceDatabase, sourceDatabaseConfig, {
+          createTablesNotToBeImported: true,
+        });
 
         // when
         const secondDayConfiguration = {
           BACKUP_MODE: {
             'knowledge-elements': 'incremental',
             'knowledge-element-snapshots': 'incremental',
-            'answers': 'incremental',
+            answers: 'incremental',
           },
           DATABASE_URL: targetDatabase._databaseUrl,
           PG_RESTORE_JOBS: 4,
@@ -515,11 +590,15 @@ describe('Integration | steps.js', () => {
         expect(answersCountBefore).to.equal(answersCountAfter);
 
         // then
-        const knowledgeElementsCountAfter = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM "knowledge-elements"'));
+        const knowledgeElementsCountAfter = parseInt(
+          await targetDatabase.runSql('SELECT COUNT(1) FROM "knowledge-elements"'),
+        );
         expect(knowledgeElementsCountBefore).to.equal(knowledgeElementsCountAfter);
 
         // then
-        const knowledgeElementSnapshotsCountAfter = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM "knowledge-element-snapshots"'));
+        const knowledgeElementSnapshotsCountAfter = parseInt(
+          await targetDatabase.runSql('SELECT COUNT(1) FROM "knowledge-element-snapshots"'),
+        );
         expect(knowledgeElementSnapshotsCountBefore).to.equal(knowledgeElementSnapshotsCountAfter);
       });
 
@@ -528,7 +607,11 @@ describe('Integration | steps.js', () => {
 
         // Source: create backup
         const sourceDatabase = await Database.create(sourceDatabaseConfig);
-        const firstDaySourceBackupFile = await createBackup(sourceDatabase, sourceDatabaseConfig, { createTablesNotToBeImported: true, createForeignKeys: true, dropDatabase: false });
+        const firstDaySourceBackupFile = await createBackup(sourceDatabase, sourceDatabaseConfig, {
+          createTablesNotToBeImported: true,
+          createForeignKeys: true,
+          dropDatabase: false,
+        });
 
         // Target : restore backup
         const targetDatabase = await Database.create(targetDatabaseConfig);
@@ -548,7 +631,9 @@ describe('Integration | steps.js', () => {
         // Day 2
 
         // Source : add data and create backup
-        await sourceDatabase.runSql(`INSERT INTO ${sourceDatabaseConfig.tableName}(id) VALUES(${sourceDatabaseConfig.tableRowCount + 1})`);
+        await sourceDatabase.runSql(
+          `INSERT INTO ${sourceDatabaseConfig.tableName}(id) VALUES(${sourceDatabaseConfig.tableRowCount + 1})`,
+        );
         await sourceDatabase.runSql('INSERT INTO referencing (id) VALUES (3)');
         const secondDaySourceBackupFile = await sourceDatabase.createBackup();
 
@@ -560,14 +645,17 @@ describe('Integration | steps.js', () => {
           BACKUP_MODE: {
             'knowledge-elements': 'incremental',
             'knowledge-element-snapshots': 'incremental',
-            'answers': 'incremental' },
+            answers: 'incremental',
+          },
         };
 
         // when
         await steps.dropObjectAndRestoreBackup(secondDaySourceBackupFile, secondDayTargetConfiguration);
 
         // then
-        const countAfter = parseInt(await targetDatabase.runSql(`SELECT COUNT(1) FROM ${sourceDatabaseConfig.tableName}`));
+        const countAfter = parseInt(
+          await targetDatabase.runSql(`SELECT COUNT(1) FROM ${sourceDatabaseConfig.tableName}`),
+        );
         expect(countAfter).to.equal(sourceDatabaseConfig.tableRowCount + 1);
 
         const referencingCountAfter = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM referencing'));
@@ -580,17 +668,25 @@ describe('Integration | steps.js', () => {
 
       // Day 1
       const firstDayTargetConfiguration = { BACKUP_MODE: {}, PG_RESTORE_JOBS: 4 };
-      await createBackUpFromSourceAndRestoreToTarget(sourceDatabase, sourceDatabaseConfig, targetDatabaseConfig.databaseUrl, firstDayTargetConfiguration);
+      await createBackUpFromSourceAndRestoreToTarget(
+        sourceDatabase,
+        sourceDatabaseConfig,
+        targetDatabaseConfig.databaseUrl,
+        firstDayTargetConfiguration,
+      );
       await sourceDatabase.dropDatabase();
 
       // Day 2
       sourceDatabase = await Database.create(sourceDatabaseConfig);
-      const secondDayBackupFile = await createBackup(sourceDatabase, sourceDatabaseConfig, { createTablesNotToBeImported: true, createFunction: true });
+      const secondDayBackupFile = await createBackup(sourceDatabase, sourceDatabaseConfig, {
+        createTablesNotToBeImported: true,
+        createFunction: true,
+      });
       const secondDayTargetConfiguration = {
         BACKUP_MODE: {
           'knowledge-elements': 'incremental',
           'knowledge-element-snapshots': 'incremental',
-          'answers': 'incremental',
+          answers: 'incremental',
         },
         DATABASE_URL: targetDatabase._databaseUrl,
         PG_RESTORE_JOBS: 4,
@@ -607,11 +703,9 @@ describe('Integration | steps.js', () => {
   });
 
   describe('#importAirtableData', () => {
-
     let targetDatabaseConfig;
     let targetDatabase;
-    before(async() => {
-
+    before(async () => {
       // CircleCI set up environment variables to access DB, so we need to read them here
       // eslint-disable-next-line no-process-env
       const TARGET_DATABASE_URL = process.env.TARGET_DATABASE_URL || 'postgres://pix@localhost:5432/replication_target';
@@ -630,9 +724,7 @@ describe('Integration | steps.js', () => {
     });
 
     context('according to Airtable API status', () => {
-
       it('if available, should import data', async function() {
-
         // when
         const configuration = {
           AIRTABLE_API_KEY: 'keyblo10ZCvCqBAJg',
@@ -647,11 +739,9 @@ describe('Integration | steps.js', () => {
         // then
         const competenceRowCount = parseInt(await targetDatabase.runSql('SELECT COUNT(*) FROM competences'));
         expect(competenceRowCount).to.be.above(0);
-
       });
 
       it('if available but credentials are invalid, should not retry the expect time, but throw', async function() {
-
         // given
         const configuration = {
           DATABASE_URL: targetDatabaseConfig.databaseUrl,
@@ -675,22 +765,19 @@ describe('Integration | steps.js', () => {
         // then
         expect(errorMessage).to.eq('Could not find what you are looking for');
         expect(elapsedTimeMinutes).to.eq(0);
-
       });
-
     });
-
   });
 
   describe('#createBackup', () => {
-
     // eslint-disable-next-line no-process-env
-    const SOURCE_DATABASE_URL = process.env.SOURCE_DATABASE_URL || 'postgres://postgres@localhost:5432/replication_source';
+    const SOURCE_DATABASE_URL =
+      process.env.SOURCE_DATABASE_URL || 'postgres://postgres@localhost:5432/replication_source';
 
     let sourceDatabase;
     let sourceDatabaseConfig;
 
-    before(async() => {
+    before(async () => {
       const rawSourceDataBaseConfig = pgUrlParser(SOURCE_DATABASE_URL);
 
       sourceDatabaseConfig = {
@@ -716,7 +803,7 @@ describe('Integration | steps.js', () => {
         BACKUP_MODE: {
           'knowledge-elements': 'incremental',
           'knowledge-element-snapshots': 'incremental',
-          'answers': 'incremental',
+          answers: 'incremental',
         },
         SOURCE_DATABASE_URL,
       };
@@ -729,5 +816,4 @@ describe('Integration | steps.js', () => {
       expect(result).to.be.true;
     });
   });
-
 });

--- a/test/integration/test-helper.js
+++ b/test/integration/test-helper.js
@@ -1,4 +1,8 @@
-async function createBackupAndCreateEmptyDatabase(database, databaseConfig, { createTablesNotToBeImported = false, createForeignKeys = false }) {
+async function createBackupAndCreateEmptyDatabase(
+  database,
+  databaseConfig,
+  { createTablesNotToBeImported = false, createForeignKeys = false },
+) {
   await createAndFillDatabase(database, databaseConfig, { createTablesNotToBeImported, createForeignKeys });
   const backupFile = await database.createBackup();
   await database.dropDatabase();
@@ -6,13 +10,16 @@ async function createBackupAndCreateEmptyDatabase(database, databaseConfig, { cr
   return backupFile;
 }
 
-async function createBackup(database, databaseConfig, {
-  createTablesNotToBeImported = false,
-  createForeignKeys = false,
-  createFunction = false,
-  dropDatabase = true,
-}) {
-  await createAndFillDatabase(database, databaseConfig, { createTablesNotToBeImported, createForeignKeys, createFunction });
+async function createBackup(
+  database,
+  databaseConfig,
+  { createTablesNotToBeImported = false, createForeignKeys = false, createFunction = false, dropDatabase = true },
+) {
+  await createAndFillDatabase(database, databaseConfig, {
+    createTablesNotToBeImported,
+    createForeignKeys,
+    createFunction,
+  });
   const backupFile = await database.createBackup();
   if (dropDatabase) {
     await database.dropDatabase();
@@ -20,11 +27,11 @@ async function createBackup(database, databaseConfig, {
   return backupFile;
 }
 
-async function createAndFillDatabase(database, databaseConfig, {
-  createTablesNotToBeImported = false,
-  createForeignKeys = false,
-  createFunction = false,
-}) {
+async function createAndFillDatabase(
+  database,
+  databaseConfig,
+  { createTablesNotToBeImported = false, createForeignKeys = false, createFunction = false },
+) {
   await createTables(database, databaseConfig);
   await fillTables(database, databaseConfig);
   await createTableToBeIndexed(database);
@@ -48,8 +55,12 @@ async function createTableToBeBaseForView(database) {
 async function createTablesThatMayNotBeRestored(database) {
   await database.runSql('CREATE TABLE answers (id int NOT NULL PRIMARY KEY, "challengeId" CHARACTER VARYING(255) )');
   await database.runSql('INSERT INTO answers (id, "challengeId") VALUES (1,2)');
-  await database.runSql('CREATE TABLE "knowledge-elements" (id int NOT NULL PRIMARY KEY, "userId" INTEGER, "createdAt" TIMESTAMP WITH TIME ZONE)');
-  await database.runSql('INSERT INTO "knowledge-elements"  (id, "userId", "createdAt") VALUES (1, 2, CURRENT_TIMESTAMP)');
+  await database.runSql(
+    'CREATE TABLE "knowledge-elements" (id int NOT NULL PRIMARY KEY, "userId" INTEGER, "createdAt" TIMESTAMP WITH TIME ZONE)',
+  );
+  await database.runSql(
+    'INSERT INTO "knowledge-elements"  (id, "userId", "createdAt") VALUES (1, 2, CURRENT_TIMESTAMP)',
+  );
   await database.runSql(`create table "knowledge-element-snapshots"
     (
       id serial
@@ -61,7 +72,9 @@ async function createTablesThatMayNotBeRestored(database) {
       constraint knowledge_element_snapshots_userid_snappedat_unique
       unique ("userId", "snappedAt")
     );`);
-  await database.runSql('INSERT INTO "knowledge-element-snapshots"  (id, "userId", "snappedAt", "snapshot") VALUES (1, 2, CURRENT_TIMESTAMP, \'{"id": "3"}\'::jsonb)');
+  await database.runSql(
+    'INSERT INTO "knowledge-element-snapshots"  (id, "userId", "snappedAt", "snapshot") VALUES (1, 2, CURRENT_TIMESTAMP, \'{"id": "3"}\'::jsonb)',
+  );
   await database.runSql('CREATE INDEX "knowledge_elements_userid_index" ON "knowledge-elements" ("userId")');
 }
 

--- a/test/unit/steps_test.js
+++ b/test/unit/steps_test.js
@@ -6,7 +6,6 @@ const { expect } = chai;
 const proxyquire = require('proxyquire').noPreserveCache();
 
 describe('Unit | steps.js', () => {
-
   describe('#createBackup', () => {
     let execStub;
     let createBackup;
@@ -35,15 +34,19 @@ describe('Unit | steps.js', () => {
         [
           '--clean',
           '--if-exists',
-          '--format', 'c',
-          '--dbname', 'postgresql://source.url',
+          '--format',
+          'c',
+          '--dbname',
+          'postgresql://source.url',
           '--no-owner',
           '--no-privileges',
           '--no-comments',
           '--exclude-schema',
           'information_schema',
-          '--exclude-schema', '\'^pg_*\'',
-          '--file', './dump.pgsql',
+          '--exclude-schema',
+          '\'^pg_*\'',
+          '--file',
+          './dump.pgsql',
         ],
         { stdio: 'inherit' },
       );
@@ -55,7 +58,11 @@ describe('Unit | steps.js', () => {
         // given
         const configuration = {
           SOURCE_DATABASE_URL: 'postgresql://source.url',
-          BACKUP_MODE: { 'knowledge-elements': 'incremental', 'knowledge-element-snapshots': 'incremental', 'answers': 'incremental' },
+          BACKUP_MODE: {
+            'knowledge-elements': 'incremental',
+            'knowledge-element-snapshots': 'incremental',
+            answers: 'incremental',
+          },
         };
 
         // when
@@ -67,22 +74,28 @@ describe('Unit | steps.js', () => {
           [
             '--clean',
             '--if-exists',
-            '--format', 'c',
-            '--dbname', 'postgresql://source.url',
+            '--format',
+            'c',
+            '--dbname',
+            'postgresql://source.url',
             '--no-owner',
             '--no-privileges',
             '--no-comments',
             '--exclude-schema',
             'information_schema',
-            '--exclude-schema', '\'^pg_*\'',
-            '--file', './dump.pgsql',
-            '--exclude-table', 'knowledge-elements',
-            '--exclude-table', 'knowledge-element-snapshots',
-            '--exclude-table', 'answers',
+            '--exclude-schema',
+            '\'^pg_*\'',
+            '--file',
+            './dump.pgsql',
+            '--exclude-table',
+            'knowledge-elements',
+            '--exclude-table',
+            'knowledge-element-snapshots',
+            '--exclude-table',
+            'answers',
           ],
           { stdio: 'inherit' },
         );
-
       });
     });
 
@@ -91,7 +104,7 @@ describe('Unit | steps.js', () => {
         // given
         const configuration = {
           SOURCE_DATABASE_URL: 'postgresql://source.url',
-          BACKUP_MODE: { 'knowledge-elements': 'none', 'knowledge-element-snapshots': 'none', 'answers': 'none' },
+          BACKUP_MODE: { 'knowledge-elements': 'none', 'knowledge-element-snapshots': 'none', answers: 'none' },
         };
 
         // when
@@ -103,25 +116,29 @@ describe('Unit | steps.js', () => {
           [
             '--clean',
             '--if-exists',
-            '--format', 'c',
-            '--dbname', 'postgresql://source.url',
+            '--format',
+            'c',
+            '--dbname',
+            'postgresql://source.url',
             '--no-owner',
             '--no-privileges',
             '--no-comments',
             '--exclude-schema',
             'information_schema',
-            '--exclude-schema', '\'^pg_*\'',
-            '--file', './dump.pgsql',
-            '--exclude-table', 'knowledge-elements',
-            '--exclude-table', 'knowledge-element-snapshots',
-            '--exclude-table', 'answers',
+            '--exclude-schema',
+            '\'^pg_*\'',
+            '--file',
+            './dump.pgsql',
+            '--exclude-table',
+            'knowledge-elements',
+            '--exclude-table',
+            'knowledge-element-snapshots',
+            '--exclude-table',
+            'answers',
           ],
           { stdio: 'inherit' },
         );
-
       });
     });
-
   });
-
 });

--- a/test/utils/database.js
+++ b/test/utils/database.js
@@ -3,7 +3,6 @@ const tmp = require('tmp-promise');
 const pgUrlParser = require('pg-connection-string').parse;
 
 module.exports = class Database {
-
   constructor(serverUrl, databaseName) {
     this._serverUrl = serverUrl;
     this._databaseName = databaseName;
@@ -24,7 +23,9 @@ module.exports = class Database {
 
   async runSql(...sqlCommands) {
     const { stdout } = await execa('psql', [
-      this._databaseUrl, '--tuples-only', '--no-align',
+      this._databaseUrl,
+      '--tuples-only',
+      '--no-align',
       ...sqlCommands.map((sqlCommand) => `--command=${sqlCommand}`),
     ]);
     return stdout;
@@ -32,7 +33,9 @@ module.exports = class Database {
 
   async runSqlAsSuperUser(...sqlCommands) {
     const { stdout } = await execa('psql', [
-      this._superUserDatabaseUrl, '--tuples-only', '--no-align',
+      this._superUserDatabaseUrl,
+      '--tuples-only',
+      '--no-align',
       ...sqlCommands.map((sqlCommand) => `--command=${sqlCommand}`),
     ]);
     return stdout;
@@ -48,25 +51,30 @@ module.exports = class Database {
   }
 
   async createDatabase() {
-    await execa('psql', [ this._superUserServerUrl,
-      '--echo-all', '--set', 'ON_ERROR_STOP=on', '--command', `CREATE DATABASE "${this._databaseName}"`,
+    await execa('psql', [
+      this._superUserServerUrl,
+      '--echo-all',
+      '--set',
+      'ON_ERROR_STOP=on',
+      '--command',
+      `CREATE DATABASE "${this._databaseName}"`,
     ]);
   }
 
   async dropDatabase() {
-    await execa('psql', [ this._superUserServerUrl,
-      '--echo-all', '--set', 'ON_ERROR_STOP=on', '--command', `DROP DATABASE IF EXISTS "${this._databaseName}"`,
+    await execa('psql', [
+      this._superUserServerUrl,
+      '--echo-all',
+      '--set',
+      'ON_ERROR_STOP=on',
+      '--command',
+      `DROP DATABASE IF EXISTS "${this._databaseName}"`,
     ]);
   }
 
   async createBackup() {
     const path = await tmp.tmpName();
-    await execa('pg_dump', [
-      '--format=c',
-      `--file=${path}`,
-      this._superUserDatabaseUrl,
-    ], { stdio: 'inherit' });
+    await execa('pg_dump', ['--format=c', `--file=${path}`, this._superUserDatabaseUrl], { stdio: 'inherit' });
     return path;
   }
-
 };

--- a/utils/parse-replication-logs.js
+++ b/utils/parse-replication-logs.js
@@ -18,9 +18,9 @@ function _printPrettyTimeElapsedBetweenTwoDates(olderDate, date) {
 
 function _printPrettyTimeElapsed(secondsElapsed) {
   const hours = Math.trunc(secondsElapsed / 60 / 60);
-  const secondsMinusHours = secondsElapsed - (hours * 60 * 60);
+  const secondsMinusHours = secondsElapsed - hours * 60 * 60;
   const minutes = Math.trunc(secondsMinusHours / 60);
-  const seconds = Math.round(secondsMinusHours - (minutes * 60));
+  const seconds = Math.round(secondsMinusHours - minutes * 60);
   return `${hours}h ${minutes}min ${seconds}s`;
 }
 
@@ -150,13 +150,7 @@ function _compareOperation(operationA, operationB) {
 }
 
 function _categorizeAndSortByElapsed(foundItems) {
-  const {
-    sequenceItems,
-    tableDataItems,
-    constraintItems,
-    indexItems,
-    fkConstraintItems,
-  } = _categorize(foundItems);
+  const { sequenceItems, tableDataItems, constraintItems, indexItems, fkConstraintItems } = _categorize(foundItems);
 
   return {
     sequenceItems: _sortByElapsed(sequenceItems),
@@ -169,21 +163,22 @@ function _categorizeAndSortByElapsed(foundItems) {
 
 function _do(logLines) {
   const foundItems = _findItemsInLogLines(logLines);
-  const {
-    sequenceItems,
-    tableDataItems,
-    constraintItems,
-    indexItems,
-    fkConstraintItems,
-  } = _categorizeAndSortByElapsed(foundItems);
+  const { sequenceItems, tableDataItems, constraintItems, indexItems, fkConstraintItems } =
+    _categorizeAndSortByElapsed(foundItems);
 
   log(`FK CONSTRAINT total duration : ${_printPrettyTimeElapsed(fkConstraintItems.totalElapsed)}`);
   for (let i = 0; i < 3 && fkConstraintItems.operations.length > 0; ++i) {
-    log(`\t${fkConstraintItems.operations[i].operation} : ${_printPrettyTimeElapsed(fkConstraintItems.operations[i].elapsed)}`);
+    log(
+      `\t${fkConstraintItems.operations[i].operation} : ${_printPrettyTimeElapsed(
+        fkConstraintItems.operations[i].elapsed,
+      )}`,
+    );
   }
   log(`CONSTRAINT total duration : ${_printPrettyTimeElapsed(constraintItems.totalElapsed)}`);
   for (let i = 0; i < 3 && constraintItems.operations.length > 0; ++i) {
-    log(`\t${constraintItems.operations[i].operation} : ${_printPrettyTimeElapsed(constraintItems.operations[i].elapsed)}`);
+    log(
+      `\t${constraintItems.operations[i].operation} : ${_printPrettyTimeElapsed(constraintItems.operations[i].elapsed)}`,
+    );
   }
   log(`INDEX total duration : ${_printPrettyTimeElapsed(indexItems.totalElapsed)}`);
   for (let i = 0; i < 3 && indexItems.operations.length > 0; ++i) {
@@ -195,7 +190,9 @@ function _do(logLines) {
   }
   log(`TABLE DATA total duration : ${_printPrettyTimeElapsed(tableDataItems.totalElapsed)}`);
   for (let i = 0; i < 3 && tableDataItems.operations.length > 0; ++i) {
-    log(`\t${tableDataItems.operations[i].operation} : ${_printPrettyTimeElapsed(tableDataItems.operations[i].elapsed)}`);
+    log(
+      `\t${tableDataItems.operations[i].operation} : ${_printPrettyTimeElapsed(tableDataItems.operations[i].elapsed)}`,
+    );
   }
 }
 
@@ -211,8 +208,18 @@ async function main() {
     const startReplicationTimestamp = _extractTimestampFromContent(logLines, START_REPLICATION);
     const startEnrichmentTimestamp = _extractTimestampFromContent(logLines, START_ENRICHMENT);
     const endTimestamp = _extractTimestampFromLogLine(logLines.slice(-1));
-    log(`Durée de création du backup: ${_printPrettyTimeElapsedBetweenTwoDates(startBackupTimestamp, startReplicationTimestamp)}`);
-    log(`Durée de réplication: ${_printPrettyTimeElapsedBetweenTwoDates(startReplicationTimestamp, startEnrichmentTimestamp)}`);
+    log(
+      `Durée de création du backup: ${_printPrettyTimeElapsedBetweenTwoDates(
+        startBackupTimestamp,
+        startReplicationTimestamp,
+      )}`,
+    );
+    log(
+      `Durée de réplication: ${_printPrettyTimeElapsedBetweenTwoDates(
+        startReplicationTimestamp,
+        startEnrichmentTimestamp,
+      )}`,
+    );
     log(`Durée de l'enrichissement: ${_printPrettyTimeElapsedBetweenTwoDates(startEnrichmentTimestamp, endTimestamp)}`);
     log(`Durée totale: ${_printPrettyTimeElapsedBetweenTwoDates(startBackupTimestamp, endTimestamp)}`);
     _do(logLines);


### PR DESCRIPTION
## :unicorn: Problème
Voir https://github.com/1024pix/pix/pull/3538

## :robot: Solution
https://github.com/1024pix/pix/pull/3538

Lors de l'application de `lint:fix`, je passe de 423 erreurs à 183 :thinking: de type `comma-dangle` ([règle](https://eslint.org/docs/8.0.0/user-guide/migrating-to-8.0.0#comma-dangle-rule-schema-is-stricter) mise à jour dans la version de eslint)

J'ai pourtant appliqué les mêmes changements que sur [API](https://github.com/1024pix/pix/pull/3538/commits/9900eb6c663bb56f39db6277913d4968d84d9def), il n'y a que la version de eslint qui diffère.

Est-ce dû à `eslint-plugin-prettier` ? Il y a [une issue](https://github.com/prettier/eslint-plugin-prettier/issues/427)

## :rainbow: Remarques
Cette PR est dédicacée au *linterman* @sbedeau ; on continue ton travail !

Montée de version de `eslint` ([breaking changes](https://eslint.org/docs/8.0.0/user-guide/migrating-to-8.0.0))

## :100: Pour tester
Vérifier que la CI passe. 
Introduire une erreur, vérifier que `npm run lint` renvoie <> 0
