### PR TITLE
[FEATURE] Récupération des champs difficulté et discriminant de LCMS pour Metabase (PIX-4095).

### DIFF
--- a/src/replicate-learning-content.js
+++ b/src/replicate-learning-content.js
@@ -72,6 +72,8 @@ const tables = [{
     { name: 'area', type: 'text' },
     { name: 'focus', type: 'boolean', extractor: (record) => !!record['focusable'] },
     { name: 'explicativeResponse', type: 'text', extractor: (record) => record['solutionToDisplay'] },
+    { name: 'delta', type: 'numeric' },
+    { name: 'alpha', type: 'numeric' },
   ],
   indices: ['firstSkillId'],
 }, {


### PR DESCRIPTION
## :unicorn: Problème
Pour répondre aux besoins du Contenu, deux nouvelles colonnes sont à ajouter pour metabase : difficulté et discriminant

## :robot: Solution

Ajout de ces colonnes

## :rainbow: Remarques

## :100: Pour tester
