### PR TITLE
[CLEANUP] Renommage d'une variable pour plus de clarté

### DIFF
--- a/src/steps.js
+++ b/src/steps.js
@@ -49,9 +49,9 @@ async function pgclientSetup(configuration) {
 
 async function dropCurrentObjects(configuration) {
   // TODO: pass DATABASE_URL by argument
-  const tablesToDrop = getTablesWithReplicationModes(configuration, [REPLICATION_MODE.INCREMENTAL, REPLICATION_MODE.TO_EXCLUDE]);
-  if (tablesToDrop.length > 0) {
-    return dropCurrentObjectsExceptTables(configuration.DATABASE_URL, tablesToDrop);
+  const tablesToKeep = getTablesWithReplicationModes(configuration, [REPLICATION_MODE.INCREMENTAL, REPLICATION_MODE.TO_EXCLUDE]);
+  if (tablesToKeep.length > 0) {
+    return dropCurrentObjectsExceptTables(configuration.DATABASE_URL, tablesToKeep);
   }
   else return exec('psql', [ configuration.DATABASE_URL, ' --echo-all', '--set', 'ON_ERROR_STOP=on', '--command', 'DROP OWNED BY CURRENT_USER CASCADE' ]);
 }


### PR DESCRIPTION
## :unicorn: Problème
Une variable n'était pas bien nommé. Elle disait l'inverse de ce qu'il se passait.

## :robot: Solution
La renommer.

## :rainbow: Remarques
:exploding_head: 

## :100: Pour tester
1. Lancer une réplication
2. Vérifier qu'elle se finit avec succès
