### PR TITLE
[TECH] Ajouter une vue pour la table schooling registrations (PIX-4491).

### DIFF
--- a/src/create-views-for-missing-tables.js
+++ b/src/create-views-for-missing-tables.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const { runDBOperation } = require('./database-helper');
+const logger = require('./logger');
+
+async function createViewForMissingTable(configuration) {
+  await runDBOperation(async (client) => {
+    const results = await client.query('SELECT FROM "pg_tables" WHERE "tablename" = \'schooling-registrations\'');
+
+    if (results.rowCount === 0) {
+      logger.info('CREATE VIEW "schooling-registrations" IF TABLE NOT EXISTS - Started');
+      await client.query('CREATE VIEW "schooling-registrations" AS SELECT * FROM "organization-learners"');
+      logger.info('CREATE VIEW "schooling-registrations" IF TABLE NOT EXISTS - Ended');
+    }
+  }, configuration);
+}
+
+module.exports = createViewForMissingTable;

--- a/src/create-views-for-missing-tables.js
+++ b/src/create-views-for-missing-tables.js
@@ -5,7 +5,7 @@ const logger = require('./logger');
 
 async function createViewForMissingTable(configuration) {
   await runDBOperation(async (client) => {
-    const results = await client.query('SELECT FROM "pg_tables" WHERE "tablename" = \'schooling-registrations\'');
+    const results = await client.query('SELECT * FROM "pg_tables" WHERE "tablename" = \'schooling-registrations\'');
 
     if (results.rowCount === 0) {
       logger.info('CREATE VIEW "schooling-registrations" IF TABLE NOT EXISTS - Started');

--- a/src/enrichment.js
+++ b/src/enrichment.js
@@ -30,11 +30,6 @@ async function add(configuration) {
       await client.query('CREATE INDEX "users_createdAt_idx" on "users" (cast("createdAt" AT TIME ZONE \'UTC+1\' as date) DESC)');
       logger.info('CREATE INDEX "users_createdAt_idx" - Ended');
     }
-    if (!tablesToNotBeEnriched.includes('schooling-registrations')) {
-      logger.info('CREATE VIEW students - Started');
-      await client.query('CREATE VIEW students AS SELECT * FROM "schooling-registrations"');
-      logger.info('CREATE VIEW students - Ended');
-    }
   }, configuration);
 }
 

--- a/src/steps.js
+++ b/src/steps.js
@@ -8,6 +8,7 @@ const learningContent = require('./replicate-learning-content');
 const enrichment = require('./enrichment');
 const logger = require('./logger');
 const toPairs = require('lodash/toPairs');
+const createViewsForMissingTables = require('./create-views-for-missing-tables');
 
 const RESTORE_LIST_FILENAME = 'restore.list';
 
@@ -133,6 +134,11 @@ async function dropObjectAndRestoreBackup(backupFile, configuration) {
   logger.info('Start restore Backup');
   await restoreBackup({ backupFile, databaseUrl: configuration.DATABASE_URL, configuration });
   logger.info('End restore Backup');
+
+  logger.info('Start create view');
+  await createViewsForMissingTables(configuration);
+  logger.info('End create view');
+
 }
 
 async function importLearningContent(configuration) {

--- a/test/acceptance/full-dump-replication-test.js
+++ b/test/acceptance/full-dump-replication-test.js
@@ -168,12 +168,6 @@ describe('Acceptance | steps | fullReplicationAndEnrichment', () => {
       expect(answersIndexCount).to.equal(1);
 
     });
-
-    it('should create view students', async function() {
-      // then
-      const viewCount = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM pg_views vws WHERE vws.viewname = \'students\';'));
-      expect(viewCount).to.equal(1);
-    });
   });
 
 });

--- a/test/integration/create-views-for-missing-tables-test.js
+++ b/test/integration/create-views-for-missing-tables-test.js
@@ -1,0 +1,57 @@
+const { expect } = require('chai');
+const pgUrlParser = require('pg-connection-string').parse;
+
+// CircleCI set up environment variables to access DB, so we need to read them here
+// eslint-disable-next-line no-process-env
+const DATABASE_URL = process.env.TARGET_DATABASE_URL || 'postgres://pix@localhost:5432/replication_target';
+
+const Database = require('../utils/database');
+
+const createViewsForMissingTables = require('../../src/create-views-for-missing-tables');
+
+describe('Integration | createViewsForMissingTables', () => {
+  let database;
+  let configuration;
+
+  beforeEach(async function() {
+    const config = pgUrlParser(DATABASE_URL);
+
+    const databaseConfig = {
+      serverUrl: `postgres://${config.user}@${config.host}:${config.port || '5432'}`,
+      databaseName: config.database,
+      tableRowCount: 100000,
+    };
+
+    databaseConfig.databaseUrl = `${databaseConfig.serverUrl}/${databaseConfig.databaseName}`;
+    configuration = { DATABASE_URL: databaseConfig.databaseUrl };
+    database = await Database.create(databaseConfig);
+  });
+
+  afterEach(async function() {
+    await database.dropDatabase();
+  });
+
+  context('when the table \'schooling-registrations\' does not exists', () => {
+    it('create a view schooling registrations', async function() {
+      await database.runSql('CREATE TABLE "organization-learners" (id integer);');
+
+      await createViewsForMissingTables(configuration);
+
+      const result = await database.runSql('SELECT COUNT(viewname) FROM "pg_views" WHERE viewname = \'schooling-registrations\'');
+      expect(result).to.equal('1');
+    });
+  });
+
+  context('when the table \'schooling-registrations\' exists', () => {
+    it('does not create a view schooling registrations', async function() {
+      await database.runSql('CREATE TABLE "organization-learners" (id integer);');
+      await database.runSql('CREATE TABLE "schooling-registrations" (id integer);');
+
+      await createViewsForMissingTables(configuration);
+
+      const result = await database.runSql('SELECT COUNT(viewname) FROM "pg_views" WHERE viewname = \'schooling-registrations\'');
+      expect(result).to.equal('0');
+    });
+  });
+
+});

--- a/test/integration/enrichment_test.js
+++ b/test/integration/enrichment_test.js
@@ -77,9 +77,6 @@ describe('Integration | enrichment.js', () => {
 
           const usersIndexCount = parseInt(await database.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'users_createdAt_idx\''));
           expect(usersIndexCount).to.equal(indexCount);
-
-          const viewCount = parseInt(await database.runSql('SELECT COUNT(1) FROM pg_views vws WHERE vws.viewname = \'students\';'));
-          expect(viewCount).to.equal(indexCount);
         }));
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
On doit renommer la table 'schooling-registrations' sauf que metabase et l'équipe DATA utilise cette table. SI on supprime la table les tableaux metabase et les requêtes de l'équipe data ne marcheront plus.

## :robot: Solution
Ajouter une vue 'schooling-registrations' à la table 'organization-learners'. 

## :rainbow: Remarques
Normalement la vue students n'est plus utilisée je l'ai supprimée.

## :100: Pour tester
🤔 