### PR TITLE
[CLEANUP] Renomme un script 

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ scalingo run --region osc-secnum-fr1 -a pix-datawarehouse-production --size M --
 
 Lancer la réplication incrémentale
 ``` bash
-scalingo run --region osc-secnum-fr1 -a pix-datawarehouse-production --size M --detached npm run restart:incremental-learning-content-replication
+scalingo run --region osc-secnum-fr1 -a pix-datawarehouse-production --size M --detached npm run restart:incremental-replication
 ```
 
 #### Sur la BDD destinée aux externes

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "local:create-databases": "./local-setup/script/create-databases.sh",
     "local:load-databases": "./local-setup/script/load-databases.sh",
     "restart:full-replication": "node scripts/restart-replication-job.js 'Replication queue'",
-    "restart:incremental-learning-content-replication": "node scripts/restart-replication-job.js 'Incremental replication queue'",
+    "restart:incremental-replication": "node scripts/restart-replication-job.js 'Incremental replication queue'",
     "restart:learning-content-replication": "node scripts/restart-replication-job.js 'Learning Content replication queue'",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",


### PR DESCRIPTION
## :unicorn: Problème
La commande `restart:incremental-learning-content-replication` peut faire penser qu'on réplique les données de LCMS, mais en fait non.

## :robot: Solution
Renommer la commande en `restart:incremental-replication` pour signifier que l'on ne relance que les tables répliquées d'une manière incrémentale.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
N/A
