### PR TITLE
[FEATURE] Ajout d'une notification / webhook en fin de réplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,18 +49,18 @@ Deux traitements (dump et incrémentale) sont exécutés chaque nuit
 
 Lancer la réplication par dump
 ``` bash
-scalingo run --region osc-secnum-fr1 -a pix-datawarehouse-production --size M --detached npm run restart:full-replication
+scalingo run --region osc-secnum-fr1 -a pix-datawarehouse-production --detached npm run restart:full-replication
 ```
 
 Lancer la réplication incrémentale
 ``` bash
-scalingo run --region osc-secnum-fr1 -a pix-datawarehouse-production --size M --detached npm run restart:incremental-replication
+scalingo run --region osc-secnum-fr1 -a pix-datawarehouse-production --detached npm run restart:incremental-replication
 ```
 
 #### Sur la BDD destinée aux externes
 Lancer la réplication par dump
 ``` bash
-scalingo run --region osc-secnum-fr1 -a pix-datawarehouse-ex-production --size M --detached npm run restart:full-replication
+scalingo run --region osc-secnum-fr1 -a pix-datawarehouse-ex-production --detached npm run restart:full-replication
 ```
 
 #### Exécution partielle
@@ -68,7 +68,12 @@ Dans certains cas, le besoin est de relancer uniquement les opérations de fin d
 
 ##### Importer le référentiel pédagogique
 ``` bash
-scalingo run --region osc-secnum-fr1 -a pix-datawarehouse-production --size M --detached npm run restart:learning-content-replication
+scalingo run --region osc-secnum-fr1 -a pix-datawarehouse-production --detached npm run restart:learning-content-replication
+```
+
+##### Relancer les notifications de fin
+``` bash
+scalingo run --region osc-secnum-fr1 -a pix-datawarehouse-production --detached npm run restart:notification
 ```
 
 ##### Enrichissement

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "restart:full-replication": "node scripts/restart-replication-job.js 'Replication queue'",
     "restart:incremental-replication": "node scripts/restart-replication-job.js 'Incremental replication queue'",
     "restart:learning-content-replication": "node scripts/restart-replication-job.js 'Learning Content replication queue'",
+    "restart:notification": "node scripts/restart-replication-job.js 'Notification queue'",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "preinstall": "npx check-engine",

--- a/sample.env
+++ b/sample.env
@@ -111,6 +111,14 @@ RESTORE_FK_CONSTRAINTS=
 # sample: BACKUP_MODE= {"answers":"incremental", "knowledge-elements":"incremental","knowledge-elements-snapshots":"incremental"}
 BACKUP_MODE=
 
+# Spécifier les URLs de notification à appeler a la fin de la réplication
+# L'appel http se fera en POST
+# presence: optionelle
+# type: json
+# default: []
+# sample: NOTIFICATION_URLS = ["https://example.com/webhook"]
+NOTIFICATION_URLS=
+
 # URL de la BDD depuis laquelle seront récupérées les données lors du mode incrémental
 # L'utilisateur ne doit PAS etre postgres !
 #

--- a/src/config/extract-configuration-from-environment.js
+++ b/src/config/extract-configuration-from-environment.js
@@ -21,7 +21,7 @@ const extractConfigurationFromEnvironmentVariable = function() {
   try {
     BACKUP_MODE = process.env.BACKUP_MODE ? JSON.parse(process.env.BACKUP_MODE) : {};
   } catch (e) {
-    logger.error('BACKUP_INCREMENTALLY should be a JSON value');
+    logger.error('BACKUP_MODE should be a JSON value');
     throw e;
   }
   try {

--- a/src/config/extract-configuration-from-environment.js
+++ b/src/config/extract-configuration-from-environment.js
@@ -24,6 +24,12 @@ const extractConfigurationFromEnvironmentVariable = function() {
     logger.error('BACKUP_INCREMENTALLY should be a JSON value');
     throw e;
   }
+  try {
+    NOTIFICATION_URLS = process.env.NOTIFICATION_URLS ? JSON.parse(process.env.NOTIFICATION_URLS) : [];
+  } catch (e) {
+    logger.error('NOTIFICATION_URLS should be a JSON value');
+    throw e;
+  }
 
   return {
     PG_CLIENT_VERSION: process.env.PG_CLIENT_VERSION || 12,
@@ -47,6 +53,7 @@ const extractConfigurationFromEnvironmentVariable = function() {
     SENTRY_DEBUG: process.env.SENTRY_DEBUG,
     SENTRY_MAX_VALUE_LENGTH: 1000,
     REDIS_URL: process.env.REDIS_URL || 'redis://127.0.0.1:6379',
+    NOTIFICATION_URLS,
   };
 };
 

--- a/src/notification-job.js
+++ b/src/notification-job.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const axios = require('axios');
+const logger = require('./logger');
+
+async function run(configuration) {
+  logger.info('Start notification');
+
+  for (const url of configuration.NOTIFICATION_URLS) {
+    logger.info(`Notify ${url}`);
+    await notifyUrl(url);
+  }
+
+  logger.info('Notification done');
+}
+
+async function notifyUrl(url) {
+  try {
+    const response = await axios.post(url);
+    return response;
+  } catch (httpErr) {
+    logger.error(`Error on POST request to ${url}`);
+    throw (httpErr);
+  }
+}
+
+module.exports = {
+  run,
+};

--- a/src/replication_job.js
+++ b/src/replication_job.js
@@ -5,6 +5,7 @@ const initSentry = require('./sentry-init');
 const steps = require('./steps');
 const logger = require('./logger');
 const replicateIncrementally = require('./replicate-incrementally');
+const notificationJob = require('./notification-job');
 const { configuration, jobOptions, repeatableJobOptions } = require('./config');
 
 const replicationQueue = _createQueue('Replication queue');
@@ -41,6 +42,7 @@ async function main() {
   });
 
   notificationQueue.process(async function() {
+    await notificationJob.run(configuration);
     logger.info('Import and enrichment done');
   });
 

--- a/src/replication_job.js
+++ b/src/replication_job.js
@@ -38,7 +38,7 @@ async function main() {
 
   learningContentReplicationQueue.process(async function() {
     await steps.importLearningContent(configuration);
-    notificationQueue.add({}, jobOptions);
+    notificationQueue.add({}, { ...jobOptions, attempts: 1 });
   });
 
   notificationQueue.process(async function() {


### PR DESCRIPTION
## :unicorn: Problème
Nous avons besoin de synchroniser des opérations de traitement de données externe a la fin de la réplication.

## :robot: Solution
Ajouter le support de webhooks qui sont appelé en fin de process de réplication

## :rainbow: Remarques


## :100: Pour tester
1. Aller sur https://webhook.site/ et copier l'URL générer
2. Éditer le .env et rajouter la dans la variable `NOTIFICATION_URLS` `NOTIFICATION_URLS=["https://webhook.site/XXXXXXXX-XXXXX-XXXX-XXXX-XXXXXX"]`
3. Dans un terminal, lancer: ```notification=require('./src/notification-job'); notification.run(require ('./src/config/extract-configuration-from-environment')()) ```
4. Vérifier sur webhook.site que la requête est bien arrivé