### PR TITLE
[TECH] Améliorer la tracabilité des métriques de la réplication incrémentale pour une meilleure exploitation dans Datadog

### DIFF
--- a/src/replicate-incrementally.js
+++ b/src/replicate-incrementally.js
@@ -28,7 +28,13 @@ async function run(configuration) {
     const req = `SELECT MAX(id) FROM "${table}"`;
     const maxIdStr = await execStdOut('psql', [configuration.TARGET_DATABASE_URL, '--tuples-only', '--command', req]);
     const lastRecordIndexTargetBeforeReplication = parseInt(maxIdStr);
-    logger.info(`${table} last record index target ${lastRecordIndexTargetBeforeReplication}`);
+    logger.info(
+      {
+        last_record_index_before_replication: lastRecordIndexTargetBeforeReplication,
+        table_name: table,
+      },
+      `${table} last record index target ${lastRecordIndexTargetBeforeReplication}`,
+    );
 
     if (isNaN(lastRecordIndexTargetBeforeReplication)) {
       throw new Error(`${table} table must not be empty on target database`);
@@ -74,9 +80,25 @@ async function run(configuration) {
       `SELECT MAX(id) FROM ${escapeSQLIdentifier(table.name)}`,
     ]);
     const lastRecordIndexTargetAfterReplication = parseInt(maxIdStrAfterReplication);
-    logger.info(`${table.name} last record index target after replication ` + lastRecordIndexTargetAfterReplication);
 
-    logger.info(`Total of ${table.name} imported ` + (lastRecordIndexTargetAfterReplication - table.lastRecordIndex));
+    logger.info(
+      {
+        last_record_index_after_replication: lastRecordIndexTargetAfterReplication,
+        table_name: `${table.name}`,
+      },
+      `${table.name} last record index target after replication ` + lastRecordIndexTargetAfterReplication,
+    );
+
+    const totalRecordsReplicated = (lastRecordIndexTargetAfterReplication - table.lastRecordIndex);
+    logger.info(
+      {
+        last_record_index_before_replication: table.lastRecordIndex,
+        last_record_index_after_replication: lastRecordIndexTargetAfterReplication,
+        total_records_replicated: totalRecordsReplicated,
+        table_name: `${table.name}`,
+      },
+      `Total of ${table.name} imported ` + totalRecordsReplicated,
+    );
   }
 
   logger.info('Incremental replication done');


### PR DESCRIPTION
## :unicorn: Problème
La table **Answers** est volumineuse et ne contient pas d'index sur la colonne **createdAt**.
Pour déterminer le nombre d'answers crées par jour, la requête prend beaucoup de temps.
Une astuce est de se servir des logs de la réplication. Néanmoins, on ne peut pas filtrer , générer de graph sur datadog en se basant sur ces métriques.

## :robot: Solution
Tracer les métriques avec un objet json et générer des métriques persistants dans Datadog pour un meilleur suivi.

## :rainbow: Remarques
L'application pix-datawarehouse-integration contient le code de cette PR pour faire des tests.

## :100: Pour tester
> Voir le readme pour les tests en local:

Résultat des logs en local pour la table answer:

```
{"name":"pix-db-replication","hostname":"AMAC02ZG4PQLVDQ","pid":16281,"level":30,"msg":"Start incremental replication","time":"2022-06-02T13:48:09.989Z","v":0}
{"name":"pix-db-replication","hostname":"AMAC02ZG4PQLVDQ","pid":16281,"level":30,"last_record_index_before_replication":38,"table_name":"answers","msg":"answers last record index target 38","time":"2022-06-02T13:48:10.047Z","v":0}
{"name":"pix-db-replication","hostname":"AMAC02ZG4PQLVDQ","pid":16281,"level":30,"msg":"Start COPY FROM/TO through STDIN/OUT","time":"2022-06-02T13:48:10.047Z","v":0}
{"name":"pix-db-replication","hostname":"AMAC02ZG4PQLVDQ","pid":16281,"level":30,"msg":"answers table copy returned: COPY 0","time":"2022-06-02T13:48:10.079Z","v":0}
{"name":"pix-db-replication","hostname":"AMAC02ZG4PQLVDQ","pid":16281,"level":30,"last_record_index_after_replication":38,"table_name":"answers","msg":"answers last record index target after replication 38","time":"2022-06-02T13:48:10.108Z","v":0}
{"name":"pix-db-replication","hostname":"AMAC02ZG4PQLVDQ","pid":16281,"level":30,"last_record_index_before_replication":38,"last_record_index_after_replication":38,"total_records_replicated":0,"table_name":"answers","msg":"Total of answers imported 0","time":"2022-06-02T13:48:10.108Z","v":0}
{"name":"pix-db-replication","hostname":"AMAC02ZG4PQLVDQ","pid":16281,"level":30,"msg":"Incremental replication done","time":"2022-06-02T13:48:10.108Z","v":0}
```

> Vérifier que les métriques sont bien tracées sous format json.
> Vérifier qu'on peut filtrer sur les métriques dans datadog et générer des graphs dessus.
