### PR TITLE
[TECH] Améliorer la gestion des données du référentiel vides

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -1,6 +1,6 @@
 class PrimaryKeyNotNullConstraintError extends Error {
   constructor(tableName) {
-    const message = `No primary key found for table ${tableName}`;
+    const message = `At least one item to insert in table ${tableName} has no property at all`;
     super(message);
   }
 }

--- a/test/integration/database-helper_test.js
+++ b/test/integration/database-helper_test.js
@@ -73,7 +73,7 @@ describe('Integration | db-connection.js', () => {
     });
   });
 
-  describe('#saveTableData', function() {
+  describe('#saveLearningContent', function() {
 
     beforeEach(async function() {
       await database.runSql(`

--- a/test/integration/database-helper_test.js
+++ b/test/integration/database-helper_test.js
@@ -6,7 +6,6 @@ const mockLcmsGetAirtable = require('../utils/mock-lcms-get-airtable');
 const databaseHelper = require('../../src/database-helper');
 const { PrimaryKeyNotNullConstraintError } = require('../../src/errors');
 
-
 describe('Integration | db-connection.js', () => {
 
   // eslint-disable-next-line no-process-env
@@ -116,7 +115,7 @@ describe('Integration | db-connection.js', () => {
     });
 
     context('when at least one of the collection item has no property', () => {
-      it('should throw an error', async function() {
+      it('should throw a PrimaryKeyNotNullConstraintError', async function() {
         const table = {
           name: 'challenges',
           fields: [

--- a/test/integration/database-helper_test.js
+++ b/test/integration/database-helper_test.js
@@ -6,6 +6,7 @@ const mockLcmsGetAirtable = require('../utils/mock-lcms-get-airtable');
 const databaseHelper = require('../../src/database-helper');
 const { PrimaryKeyNotNullConstraintError } = require('../../src/errors');
 
+
 describe('Integration | db-connection.js', () => {
 
   // eslint-disable-next-line no-process-env
@@ -114,29 +115,32 @@ describe('Integration | db-connection.js', () => {
       expect(skillIdsCount).to.deep.equal(skillCount);
     });
 
-    it('should throw an error if at least one of the collection item has no property', async function() {
-      const table = {
-        name: 'challenges',
-        fields: [
-          { name: 'instructions', type: 'text' },
-          { name: 'timer', type: 'smallint' },
-          { name: 'autoReply', type: 'boolean' },
-          { name: 'skillIds', type: 'text []', isArray: true },
-          { name: 'skillCount', type: 'smallint', extractor: (record) => _.size(record['skillIds']) },
-          { name: 'firstSkillId', type: 'text', extractor: (record) => _.get(record['skillIds'], 0) },
-        ],
-        indices: ['firstSkillId'],
-      };
-      const fullLearningContent = {
-        challenges: [{}],
-      };
-      const learningContent = fullLearningContent[table.name];
+    context('when at least one of the collection item has no property', () => {
+      it('should throw an error', async function() {
+        const table = {
+          name: 'challenges',
+          fields: [
+            { name: 'instructions', type: 'text' },
+            { name: 'timer', type: 'smallint' },
+            { name: 'autoReply', type: 'boolean' },
+            { name: 'skillIds', type: 'text []', isArray: true },
+            { name: 'skillCount', type: 'smallint', extractor: (record) => _.size(record['skillIds']) },
+            { name: 'firstSkillId', type: 'text', extractor: (record) => _.get(record['skillIds'], 0) },
+          ],
+          indices: ['firstSkillId'],
+        };
+        const fullLearningContent = {
+          challenges: [{}],
+        };
+        const learningContent = fullLearningContent[table.name];
 
-      const error = await catchErr(databaseHelper.saveLearningContent)(table, learningContent, databaseConfig);
+        const error = await catchErr(databaseHelper.saveLearningContent)(table, learningContent, databaseConfig);
 
-      expect(error.message).to.equal('No primary key found for table challenges');
+        expect(error).to.be.instanceof(PrimaryKeyNotNullConstraintError);
+
+      });
+
     });
 
   });
-
 });

--- a/test/integration/database-helper_test.js
+++ b/test/integration/database-helper_test.js
@@ -114,7 +114,7 @@ describe('Integration | db-connection.js', () => {
       expect(skillIdsCount).to.deep.equal(skillCount);
     });
 
-    it('should throw an error if the data to be inserted has no primary key', async function() {
+    it('should throw an error if at least one of the collection item has no property', async function() {
       const table = {
         name: 'challenges',
         fields: [
@@ -134,7 +134,7 @@ describe('Integration | db-connection.js', () => {
 
       const error = await catchErr(databaseHelper.saveLearningContent)(table, learningContent, databaseConfig);
 
-      expect(error).to.be.instanceof(PrimaryKeyNotNullConstraintError);
+      expect(error.message).to.equal('No primary key found for table challenges');
     });
 
   });

--- a/test/unit/errors_test.js
+++ b/test/unit/errors_test.js
@@ -1,0 +1,18 @@
+const { expect } = require('../test-helper');
+const { PrimaryKeyNotNullConstraintError } = require('../../src/errors');
+
+describe('Unit | errors.js', () => {
+
+  describe('#PrimaryKeyNotNullConstraintError', () => {
+
+    it('should return a message', async () => {
+      // given
+      // when
+      const error = new PrimaryKeyNotNullConstraintError();
+
+      // then
+      expect(error.message).to.equal('At least one item to insert in table undefined has no property at all');
+    });
+
+  });
+});

--- a/test/unit/steps_test.js
+++ b/test/unit/steps_test.js
@@ -1,8 +1,4 @@
-const chai = require('chai');
-const sinonChai = require('sinon-chai');
-const sinon = require('sinon');
-chai.use(sinonChai);
-const { expect } = chai;
+const { expect, sinon } = require('../test-helper');
 const proxyquire = require('proxyquire').noPreserveCache();
 
 describe('Unit | steps.js', () => {
@@ -50,7 +46,7 @@ describe('Unit | steps.js', () => {
       expect(backupFilename).to.equal('./dump.pgsql');
     });
 
-    context('when anwers, knowledge elements and knowledge element snapshots are restored incrementally', () => {
+    context('when answers, knowledge elements and knowledge element snapshots are restored incrementally', () => {
       it('should not backup answers, knowledge-elements and knowledge-element-snapshots tables', async () => {
         // given
         const configuration = {
@@ -86,7 +82,7 @@ describe('Unit | steps.js', () => {
       });
     });
 
-    context('when anwers, knowledge elements and knowledge element snapshots are not restored', () => {
+    context('when answers, knowledge elements and knowledge element snapshots are not restored', () => {
       it('should not backup answers, knowledge-elements and knowledge-element-snapshots tables', async () => {
         // given
         const configuration = {


### PR DESCRIPTION
## :unicorn: Problème
Si une ligne vide est présente dans LCMS, la réplication échoue avec le message d'erreur suivant
`No primary key found for table challenges`

A cette étape, la table `challenges` a bien une clef primaire: on parle des données qui vont y être insérées.

Dans le cas de ligne vide, qui devient ici un objet vide, cette donnée ne peut être insérée en BDD car elle violerait la contrainte d'unicité assurée par la clef primaire,  n'ayant pas d'identifiant unique. Le problème est que le message d'erreur n'explicite pas le comportement.

## :robot: Solution
Modifier le message d'erreur
`At least one item to be inserted in table challenges has no property at all`

## :rainbow: Remarques
Ce code est bien couvert par les test :tada: 

## :100: Pour tester
Vérifier que la CI passe
