### PR TITLE
Dupliquer le schéma pgboss

### DIFF
--- a/src/steps.js
+++ b/src/steps.js
@@ -59,7 +59,7 @@ async function dropCurrentObjects(configuration) {
 
 async function dropCurrentObjectsExceptTables(databaseUrl, tableNames) {
   const tableNamesForQuery = tableNames.map((tableName) => `'${tableName}'`).join(',');
-  const dropTableQuery = await execStdOut('psql', [ databaseUrl, '--tuples-only', '--command', `select string_agg('drop table "' || tablename || '" CASCADE', '; ') from pg_tables where schemaname = 'public' and tablename not in (${tableNamesForQuery});` ]);
+  const dropTableQuery = await execStdOut('psql', [ databaseUrl, '--tuples-only', '--command', `SELECT string_agg('DROP TABLE IF EXISTS "' || schemaname || '"."' || tablename || '" CASCADE', '; ') FROM pg_tables WHERE schemaname IN ('public','pgboss') AND tablename NOT IN (${tableNamesForQuery});` ]);
   const dropFunction = await execStdOut('psql', [ databaseUrl, '--tuples-only', '--command', 'select string_agg(\'drop function "\' || proname || \'"\', \'; \') FROM pg_proc pp INNER JOIN pg_roles pr ON pp.proowner = pr.oid WHERE pr.rolname = current_user ' ]);
   await exec('psql', [ databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropTableQuery ]);
   return exec('psql', [ databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropFunction ]);


### PR DESCRIPTION
## :unicorn: Problème
Le code actuel supprime les objets des schémas autre que `public`
https://github.com/1024pix/pix-db-replication/blob/d7e7dc2cbb80b1f527b70207aa67a6bab930aca7/src/steps.js#L62

Or `pgboss` a un schéma dédié, il n'est donc pas répliqué

## :robot: Solution
Suite de https://github.com/1024pix/pix-db-replication/pull/115
Ne pas  supprimer les objets du schéma `pgboss`

## :rainbow: Remarques
J'ai changé le code sans changer les test et ça passe :scream_cat: 
Y a-t-il un besoin de variables d'environnement pour le rendre plus souple ?

## :100: Pour tester

### Review app
Vérifier le paramétrage

``` bash
scalingo --region osc-fr1 -app pix-datawarehouse-integration-pr122 env-get BACKUP_MODE
```
Il ne doit pas être fait mention de `pgboss`
```json
{"answers":"incremental","knowledge-elements":"incremental","knowledge-element-snapshots":"incremental","answers_with_time_spent":"none", "challenges_statistics": "none", "challenges_statistics2": "none", "data_beta_successratemean_by_skillid": "none", "data_skills_evaluation": "none", "data_feedbacks_answers_by_challenge": "none", "data_pro_secu_campaigns_kpi": "none", "data_certifications_timespent_challenges_count": "none", "data_ref_mefcode": "none", "data_ref_academies": "none", "fast_answers_by_user": "none"}
```

Lancer la réplication
``` bash
scalingo --region osc-fr1 -app pix-datawarehouse-integration-pr122 run npm run restart:full-replication
```

Vérifier la présence des données

``` bash
scalingo --region osc-fr1 -app pix-datawarehouse-integration-pr122 pgsql-console
```

```sql
SELECT * FROM pgboss.jobs LIMIT 10
```
