### PR TITLE
[TECH] Renommer indices en indexes

### DIFF
--- a/src/database-helper.js
+++ b/src/database-helper.js
@@ -30,7 +30,7 @@ async function createTable(tableStructure, configuration) {
     })).join(',\n');
     const createQuery = format('CREATE TABLE %I (%s)', tableStructure.name, fieldsText);
     await client.query(createQuery);
-    for (const index of tableStructure.indices) {
+    for (const index of tableStructure.indexes) {
       const indexQuery = format('CREATE INDEX %I on %I (%I)', `${tableStructure.name}_${index}_idx`, tableStructure.name, index);
       await client.query(indexQuery);
     }

--- a/src/replicate-learning-content.js
+++ b/src/replicate-learning-content.js
@@ -7,7 +7,7 @@ const tables = [{
   fields: [
     { name: 'name', type: 'text' },
   ],
-  indices: [],
+  indexes: [],
 }, {
   name: 'attachments',
   fields: [
@@ -17,7 +17,7 @@ const tables = [{
     { name: 'url', type: 'text' },
     { name: 'size', type: 'numeric' },
   ],
-  indices: [],
+  indexes: [],
 }, {
   name: 'competences',
   fields: [
@@ -27,7 +27,7 @@ const tables = [{
     { name: 'origin', type: 'text' },
     { name: 'areaId', type: 'text', isArray: false },
   ],
-  indices: ['areaId'],
+  indexes: ['areaId'],
 }, {
   name: 'tubes',
   fields: [
@@ -35,7 +35,7 @@ const tables = [{
     { name: 'title', type: 'text' },
     { name: 'competenceId', type: 'text', isArray: false },
   ],
-  indices: ['competenceId'],
+  indexes: ['competenceId'],
 }, {
   name: 'skills',
   fields: [
@@ -50,7 +50,7 @@ const tables = [{
     { name: 'learningMoreTutorialIds', type: 'text []', isArray: true },
     { name: 'internationalisation', type: 'text' },
   ],
-  indices: ['tubeId'],
+  indexes: ['tubeId'],
 }, {
   name: 'challenges',
   fields: [
@@ -76,7 +76,7 @@ const tables = [{
     { name: 'delta', type: 'numeric' },
     { name: 'alpha', type: 'numeric' },
   ],
-  indices: ['firstSkillId'],
+  indexes: ['firstSkillId'],
 }, {
   name: 'courses',
   fields: [
@@ -85,7 +85,7 @@ const tables = [{
     { name: 'competences', type: 'text[]', isArray: true },
     { name: 'competenceId', type: 'text', extractor: (record) => _.get(record['competences'], 0) },
   ],
-  indices: ['competenceId'],
+  indexes: ['competenceId'],
 }, {
   name: 'tutorials',
   fields: [
@@ -95,7 +95,7 @@ const tables = [{
     { name: 'furtherInformation', type: 'text []', isArray: true },
     { name: 'locale', type: 'text' },
   ],
-  indices: ['title'],
+  indexes: ['title'],
 }];
 
 async function fetchAndSaveData(configuration) {

--- a/test/integration/database-helper_test.js
+++ b/test/integration/database-helper_test.js
@@ -58,7 +58,7 @@ describe('Integration | db-connection.js', () => {
           { name: 'name', type: 'text' },
           { name: 'areaId', type: 'text', isArray: false },
         ],
-        indices: ['areaId'],
+        indexes: ['areaId'],
       };
       const tableName = tableStructure.name;
 
@@ -100,7 +100,7 @@ describe('Integration | db-connection.js', () => {
           { name: 'skillCount', type: 'smallint', extractor: (record) => _.size(record['skillIds']) },
           { name: 'firstSkillId', type: 'text', extractor: (record) => _.get(record['skillIds'], 0) },
         ],
-        indices: ['firstSkillId'],
+        indexes: ['firstSkillId'],
       };
       const fullLearningContent = mockLcmsGetAirtable();
       const learningContent = fullLearningContent[table.name];
@@ -126,7 +126,7 @@ describe('Integration | db-connection.js', () => {
             { name: 'skillCount', type: 'smallint', extractor: (record) => _.size(record['skillIds']) },
             { name: 'firstSkillId', type: 'text', extractor: (record) => _.get(record['skillIds'], 0) },
           ],
-          indices: ['firstSkillId'],
+          indexes: ['firstSkillId'],
         };
         const fullLearningContent = {
           challenges: [{}],


### PR DESCRIPTION
## :unicorn: Problème
La variable `indices` est une collection de champ sur lesquels créer des indexs en BDD.

Les deux formes `indexes` et `indices` sont correctes.
> Both plurals indices and [indexes](https://en.wiktionary.org/wiki/indexes) are in common use.

Mais le première est la plus répandue chez Pix, voir par exemple CLI PosgreSQL

```
Indexes:
    "users_pkey" PRIMARY KEY, btree (id)
    "users_email_lower" btree (lower(email::text))
```

## :robot: Solution
Utiliser le terme `indexes`

## :rainbow: Remarques
[Les ngrams](https://books.google.com/ngrams/graph?content=indexes%2Cindices&year_start=1970&year_end=2019&corpus=26&smoothing=3) dressent un tableau différent.

## :100: Pour tester
Vérifier que la CI passe
