### PR TITLE
Monter la version de PG de 13 à 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
   test:
     docker:
       - image: cimg/node:14.15.4
-      - image: postgres:13.3-alpine
+      - image: postgres:14.6-alpine
         environment:
           POSTGRES_USER: postgres
           POSTGRES_HOST_AUTH_METHOD: trust
@@ -84,9 +84,9 @@ jobs:
           command: |
             sudo apt update
       - run :
-          name : Install PG13 client package
+          name : Install PostgreSQL client package
           command: |
-            sudo apt install postgresql-client-13
+            sudo apt install postgresql-client-14
       - run :
           name : Checking pg_dump version
           command: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   database:
     container_name: database
-    image: postgres:13.3-alpine
+    image: postgres:14.6-alpine
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
     restart: unless-stopped


### PR DESCRIPTION
## :unicorn: Problème
On est en 13.
La v14 est disponible sur Scalingo.
https://www.postgresql.org/docs/14/release-14.html

## :robot: Solution
Monter en 14.

## :rainbow: Remarques
A merger après l'API sinon erreur de version de dump.
Déjà monté sur `pix-datawarehouse-integration`.

## :100: Pour tester
Vérifier la CI
