### PR TITLE
[BUGFIX] Correction de l'extraction de l'attribut name des compétences

### DIFF
--- a/src/replicate-learning-content.js
+++ b/src/replicate-learning-content.js
@@ -21,7 +21,7 @@ const tables = [{
 }, {
   name: 'competences',
   fields: [
-    { name: 'name', type: 'text' },
+    { name: 'name', type: 'text', extractor: (record) => record['name_i18n']['fr'] },
     { name: 'code', type: 'text', extractor: (record) => record['index'] },
     { name: 'title', type: 'text', extractor: (record) => record['name_i18n']['fr'] },
     { name: 'origin', type: 'text' },


### PR DESCRIPTION
## :unicorn: Problème
Lors de https://github.com/1024pix/pix-db-replication/pull/125, l'attribut title a été changer pour récupérer la valeur "i18n", mais l'attribut name a été oublié.

## :robot: Solution
Corriger ça.

## :rainbow: Remarques
Le fait que nous ayons une propriété title qui est redondante est pas super cool, a voir pour la supprimer.
