### PR TITLE
[FEATURE] Mise a jour de la version par défaut de pg

### DIFF
--- a/src/config/extract-configuration-from-environment.js
+++ b/src/config/extract-configuration-from-environment.js
@@ -32,7 +32,7 @@ const extractConfigurationFromEnvironmentVariable = function() {
   }
 
   return {
-    PG_CLIENT_VERSION: process.env.PG_CLIENT_VERSION || 12,
+    PG_CLIENT_VERSION: process.env.PG_CLIENT_VERSION || 14,
     RETRIES_TIMEOUT_MINUTES: extractInteger(process.env.RETRIES_TIMEOUT_MINUTES) || 180,
     LCMS_API_KEY: process.env.LCMS_API_KEY || '',
     LCMS_API_URL: process.env.LCMS_API_URL || '',


### PR DESCRIPTION
## :unicorn: Problème
La version pg en production est en 14, mais la version par défaut des outils pg téléchargé est 12.

## :robot: Solution
Passer a la version 14 par défaut
