### PR TITLE
[BUGFIX] Rajout d'un timeout sur la requête LCMS

### DIFF
--- a/src/lcms-client.js
+++ b/src/lcms-client.js
@@ -5,6 +5,7 @@ async function getLearningContent(configuration) {
   const url = configuration.LCMS_API_URL + '/databases/airtable';
   const requestConfig = {
     headers: { 'Authorization': `Bearer ${configuration.LCMS_API_KEY}` },
+    timeout: 10000,
   };
 
   try {

--- a/src/lcms-client.js
+++ b/src/lcms-client.js
@@ -5,7 +5,7 @@ async function getLearningContent(configuration) {
   const url = configuration.LCMS_API_URL + '/databases/airtable';
   const requestConfig = {
     headers: { 'Authorization': `Bearer ${configuration.LCMS_API_KEY}` },
-    timeout: 10000,
+    timeout: 60000,
   };
 
   try {

--- a/test/unit/lcms-client_test.js
+++ b/test/unit/lcms-client_test.js
@@ -23,7 +23,7 @@ describe('Unit | lcms-client.js', () => {
         data: {},
         status: 'someStatus',
       };
-      sinon.stub(axios, 'get').withArgs(learningContentGetUrl, { headers }).resolves(axiosResponse);
+      sinon.stub(axios, 'get').withArgs(learningContentGetUrl, { headers, timeout: 10000 }).resolves(axiosResponse);
 
       // when
       const response = await lcmsClient.getLearningContent(configuration);
@@ -39,7 +39,7 @@ describe('Unit | lcms-client.js', () => {
           status: 'someStatus',
         },
       };
-      sinon.stub(axios, 'get').withArgs(learningContentGetUrl, { headers }).rejects(axiosError);
+      sinon.stub(axios, 'get').withArgs(learningContentGetUrl, { headers, timeout: 10000 }).rejects(axiosError);
 
       // when
       const error = await catchErr(lcmsClient.getLearningContent)(configuration);

--- a/test/unit/lcms-client_test.js
+++ b/test/unit/lcms-client_test.js
@@ -23,7 +23,7 @@ describe('Unit | lcms-client.js', () => {
         data: {},
         status: 'someStatus',
       };
-      sinon.stub(axios, 'get').withArgs(learningContentGetUrl, { headers, timeout: 10000 }).resolves(axiosResponse);
+      sinon.stub(axios, 'get').withArgs(learningContentGetUrl, { headers, timeout: 60000 }).resolves(axiosResponse);
 
       // when
       const response = await lcmsClient.getLearningContent(configuration);
@@ -39,7 +39,7 @@ describe('Unit | lcms-client.js', () => {
           status: 'someStatus',
         },
       };
-      sinon.stub(axios, 'get').withArgs(learningContentGetUrl, { headers, timeout: 10000 }).rejects(axiosError);
+      sinon.stub(axios, 'get').withArgs(learningContentGetUrl, { headers, timeout: 60000 }).rejects(axiosError);
 
       // when
       const error = await catchErr(lcmsClient.getLearningContent)(configuration);


### PR DESCRIPTION
## :unicorn: Problème
Nous n'avons pas de timeout lorsqu'on requête LCMS. Si il crash on attend indéfiniment. 

## :robot: Solution
Rajouter un timeout.

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
