### PR TITLE
[FEATURE] Importer les données de LCMS par groupe de 2000 et table par table

### DIFF
--- a/src/database-helper.js
+++ b/src/database-helper.js
@@ -50,7 +50,7 @@ async function saveLearningContent(table, learningContent, configuration) {
         else {
           throw new PrimaryKeyNotNullConstraintError(table.name);
         }
-      };
+      }
     }, configuration);
   }
 }

--- a/src/database-helper.js
+++ b/src/database-helper.js
@@ -5,6 +5,8 @@ const _ = require('lodash');
 const { PrimaryKeyNotNullConstraintError } = require('./errors');
 const learningContentHelper = require('./learning-content-helper');
 
+const LCMS_CHUNK = 2000;
+
 async function runDBOperation(callback, configuration) {
   const client = new Client({
     connectionString: configuration.DATABASE_URL,
@@ -42,7 +44,7 @@ async function saveLearningContent(table, learningContent, configuration) {
   if (learningContent.length) {
     await runDBOperation(async (client) => {
       const fieldNames = ['id'].concat(table.fields.map((field) => field.name));
-      for await (const learningContentChunk of _.chunk(learningContent, 2000)) {
+      for await (const learningContentChunk of _.chunk(learningContent, LCMS_CHUNK)) {
         const values = _computeValuesToInsert(table, learningContentChunk);
         if (_allValuesHavePrimaryKey(values)) {
           await _insertValues(table.name, fieldNames, values, client);

--- a/src/replicate-learning-content.js
+++ b/src/replicate-learning-content.js
@@ -101,11 +101,11 @@ const tables = [{
 async function fetchAndSaveData(configuration) {
   const learningContent = await lcmsClient.getLearningContent(configuration);
   if (learningContent) {
-    await Promise.all(tables.map(async (table) => {
+    for await (const table of tables) {
       await databaseHelper.dropTable(table.name, configuration);
       await databaseHelper.createTable(table, configuration);
       await databaseHelper.saveLearningContent(table, learningContent[table.name], configuration);
-    }));
+    }
   }
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Les données de LCMS sont importé d'un coup par table en simultanée. Ce qui fait exploser la mémoire avec le référentiel qui grossit.

## :robot: Solution
Importer les données séquentiellement table par table et diviser les inserts pas bloc de 2000 lignes.

## :100: Pour tester
Lancer la réplication et voir que toutes les données sont insérées.
