### PR TITLE
:sparkles: Fetch CPF formations list from open data

### DIFF
--- a/cpf/scripts/fetch-cpf-formations.sh
+++ b/cpf/scripts/fetch-cpf-formations.sh
@@ -1,0 +1,28 @@
+#! /bin/bash
+
+set -eu
+
+dbclient-fetcher pgsql "$PG_CLIENT_VERSION"
+
+TABLE_NAME='pole_formation_cpf_list'
+DATASET_URL='https://opendata.caissedesdepots.fr/api/records/1.0/search/?dataset=moncompteformation_catalogueformation&rows=2000&q=pix&facet=nom_departement&facet=nom_region&facet=rsrncp&facet=libelle_niveau_sortie_formation&facet=libelle_nsf_1&facet=code_certifinfo&facet=siret&facet=code_region&refine.rsrncp=RS'
+OUTPUT_FILE='/tmp/exportcpf.csv'
+
+psql "$DATABASE_URL" \
+    -c "DROP TABLE IF EXISTS $TABLE_NAME; CREATE TABLE IF NOT EXISTS $TABLE_NAME (record_id TEXT, date_extract DATE, nom_of TEXT, intitule_formation TEXT, numero_formation TEXT)"
+
+curl "$DATASET_URL" \
+> /tmp/export.json
+
+jq -r '.records[]|
+    [ 
+        .recordid,
+        .fields.date_extract, 
+        .fields.nom_of, 
+        .fields.intitule_formation, 
+        .fields.numero_formation
+    ]|
+    join(";")' /tmp/export.json \
+> "$OUTPUT_FILE"
+
+psql "$DATABASE_URL" -c "\copy $TABLE_NAME FROM '$OUTPUT_FILE' DELIMITER ';';"

--- a/cron.json
+++ b/cron.json
@@ -1,0 +1,7 @@
+{
+    "jobs": [
+        {
+            "command": "0 0 * * 1 ./cpf/scripts/fetch-cpf-formations.sh"
+        }
+    ]
+}


### PR DESCRIPTION
## :unicorn: Problème
Nous avons besoin de suivre dans le temps les formations Pix poussées sur le CPF

## :robot: Solution
Les stocker sur nos datawarehouse toutes les semaines et lancer une analyse de données via dbt
Il faudra également rajouter le nom des deux tables (données sources + snapshots dbt) dans la liste des tables à ne pas toucher dans la réplication

## :rainbow: Remarques
Le but sera de lister les évolutions via notre outil de BI 

## :100: Pour tester
Lancer le script sur la RA et vérifier que les données insérées correspondent bien aux résultats ici :  https://opendata.caissedesdepots.fr/explore/dataset/moncompteformation_catalogueformation/api/?disjunctive.nom_departement&disjunctive.nom_region&disjunctive.libelle_niveau_sortie_formation&disjunctive.libelle_nsf_1&disjunctive.siret&disjunctive.code_region&q=pix&rows=1500&refine.rsrncp=RS&dataChart=eyJxdWVyaWVzIjpbeyJjaGFydHMiOlt7ImFsaWduTW9udGgiOnRydWUsInR5cGUiOiJiYXIiLCJmdW5jIjoiU1VNIiwieUF4aXMiOiJuYl9zZXNzaW9uX2FjdGl2ZSIsInNjaWVudGlmaWNEaXNwbGF5Ijp0cnVlLCJjb2xvciI6IiM4ZGEwY2IifSx7ImFsaWduTW9udGgiOnRydWUsInR5cGUiOiJiYXIiLCJmdW5jIjoiU1VNIiwieUF4aXMiOiJuYl9hY3Rpb24iLCJzY2llbnRpZmljRGlzcGxheSI6dHJ1ZSwiY29sb3IiOiIjZmM4ZDYyIn1dLCJ4QXhpcyI6ImxpYmVsbGVfbnNmXzEiLCJtYXhwb2ludHMiOjIwLCJ0aW1lc2NhbGUiOiIiLCJzb3J0Ijoic2VyaWUxLTEiLCJjb25maWciOnsiZGF0YXNldCI6Im1vbmNvbXB0ZWZvcm1hdGlvbl9jYXRhbG9ndWVmb3JtYXRpb24iLCJvcHRpb25zIjp7ImRpc2p1bmN0aXZlLm5vbV9kZXBhcnRlbWVudCI6dHJ1ZSwiZGlzanVuY3RpdmUubm9tX3JlZ2lvbiI6dHJ1ZSwiZGlzanVuY3RpdmUubGliZWxsZV9uaXZlYXVfc29ydGllX2Zvcm1hdGlvbiI6dHJ1ZSwiZGlzanVuY3RpdmUubGliZWxsZV9uc2ZfMSI6dHJ1ZSwiZGlzanVuY3RpdmUuc2lyZXQiOnRydWUsImRpc2p1bmN0aXZlLmNvZGVfcmVnaW9uIjp0cnVlLCJxIjoicGl4IiwicmVmaW5lLnJzcm5jcCI6IlJTIn19fV0sImRpc3BsYXlMZWdlbmQiOnRydWUsImFsaWduTW9udGgiOnRydWUsInRpbWVzY2FsZSI6IiIsInNpbmdsZUF4aXMiOnRydWV9
