### PR TITLE
[BUGFIX] Corrige le timeout de axios avec un signal

### DIFF
--- a/src/lcms-client.js
+++ b/src/lcms-client.js
@@ -1,11 +1,13 @@
 const axios = require('axios');
 const logger = require('./logger');
 
+const timeout = 60 * 1000 * 3;
+
 async function getLearningContent(configuration) {
   const url = configuration.LCMS_API_URL + '/databases/airtable';
   const requestConfig = {
     headers: { 'Authorization': `Bearer ${configuration.LCMS_API_KEY}` },
-    timeout: 60000,
+    signal: AbortSignal.timeout(configuration.timeout || timeout),
   };
 
   try {
@@ -13,7 +15,7 @@ async function getLearningContent(configuration) {
     return response.data;
   } catch (httpErr) {
     logger.error(`Error on GET request to ${url}`);
-    throw (httpErr);
+    throw httpErr;
   }
 }
 

--- a/test/integration/lcms-client_test.js
+++ b/test/integration/lcms-client_test.js
@@ -1,0 +1,58 @@
+const { expect, catchErr, nock } = require('../test-helper');
+
+const lcmsClient = require('../../src/lcms-client');
+
+describe('Integration | lcms-client.js', () => {
+  describe('#getLatest', () => {
+    let configuration;
+
+    beforeEach(() => {
+      const lcmsApiUrl = 'https://lcms-test.pix.fr/api';
+      const lcmsApiKey = 'abcd';
+      configuration = {
+        LCMS_API_URL: lcmsApiUrl,
+        LCMS_API_KEY: lcmsApiKey,
+      };
+      nock.disableNetConnect();
+    });
+
+    afterEach(() => {
+      nock.cleanAll();
+    });
+
+    it('should call LCMS API to get learning content latest release', async () => {
+      // given
+      nock('https://lcms-test.pix.fr', {
+        reqheaders: {
+          authorization: 'Bearer abcd',
+        } })
+        .get('/api/databases/airtable')
+        .reply(200, '{}');
+
+      // when
+      const response = await lcmsClient.getLearningContent(configuration);
+
+      // then
+      expect(response).to.deep.equal({});
+    });
+
+    it('should throw an error when the response take more than the allowed time', async () => {
+      // given
+      nock('https://lcms-test.pix.fr', {
+        reqheaders: {
+          authorization: 'Bearer abcd',
+        } })
+        .get('/api/databases/airtable')
+        .delay(100)
+        .reply(200, '{}');
+
+      configuration.timeout = 50;
+
+      // when
+      const err = await catchErr(lcmsClient.getLearningContent)(configuration);
+
+      // then
+      expect(err.name).to.equal('CanceledError');
+    });
+  });
+});

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const sinon = require('sinon');
 const chai = require('chai');
+const nock = require('nock');
 const { expect } = chai;
 chai.use(require('sinon-chai'));
 
@@ -20,8 +21,9 @@ function catchErr(promiseFn, ctx) {
 }
 
 module.exports = {
-  expect,
   axios,
-  sinon,
   catchErr,
+  expect,
+  nock,
+  sinon,
 };

--- a/test/unit/lcms-client_test.js
+++ b/test/unit/lcms-client_test.js
@@ -23,7 +23,7 @@ describe('Unit | lcms-client.js', () => {
         data: {},
         status: 'someStatus',
       };
-      sinon.stub(axios, 'get').withArgs(learningContentGetUrl, { headers, timeout: 60000 }).resolves(axiosResponse);
+      sinon.stub(axios, 'get').withArgs(learningContentGetUrl, { headers, signal: sinon.match.any }).resolves(axiosResponse);
 
       // when
       const response = await lcmsClient.getLearningContent(configuration);
@@ -39,7 +39,7 @@ describe('Unit | lcms-client.js', () => {
           status: 'someStatus',
         },
       };
-      sinon.stub(axios, 'get').withArgs(learningContentGetUrl, { headers, timeout: 60000 }).rejects(axiosError);
+      sinon.stub(axios, 'get').withArgs(learningContentGetUrl, { headers, signal: sinon.match.any }).rejects(axiosError);
 
       // when
       const error = await catchErr(lcmsClient.getLearningContent)(configuration);


### PR DESCRIPTION
## :unicorn: Problème
Le timeout de axios que nous avions rajouté ne fonctionne pas comme on le voudrait. Si la réponse n'est pas donné dans les 3 minutes, on souhaite retourner une erreur.

## :robot: Solution
Utiliser les nouvelles fonctionnalité de node 18 et le support de axios des signal. Voir: https://axios-http.com/docs/cancellation

## :100: Pour tester
Tests + integration
