### PR TITLE
[TECH] Corriger l'export des données CPF depuis l'open data

### DIFF
--- a/cpf/README.md
+++ b/cpf/README.md
@@ -1,0 +1,35 @@
+# Récupération de données externes depuis de l'open data
+
+Le dossier `cpf` de ce projet contient un script qui permet d'insérer des données de l'api de la caisse des dépots
+dans une table de la BDD.
+
+## Fonctionnement
+
+Le script télécharge un json contenant les entrées de l'API de la caisse des dépots,
+récupère les entrées désirées et génère un identifiant propre à chaque formation.
+Il insère ensuite ces données dans un fichier CSV, qu'il insère dans la BDD via la commande
+`\copy`.
+
+> **Warning**
+>
+> L'URL actuelle ne requête que 2000 résultats maximum, il conviendra de surveiller que nous ne dépassons pas ce nombre de rows
+
+## Pour tester en local
+
+Démarrer la BDD PG configurée dans `docker-compose.yml`
+
+```bash
+docker-compose up -d
+```
+
+Lancer le script de récupération des données
+
+```bash
+./scripts/fetch-cpf-formations.sh
+```
+
+Vérifier que des données sont bien insérées
+
+```bash
+docker exec database-cpf-export-local psql -U postgres -d postgres -c "select * from external_opendata_caisse_des_depots_cpf_list LIMIT 1"
+```

--- a/cpf/create-table.sql
+++ b/cpf/create-table.sql
@@ -1,0 +1,2 @@
+-- .recordid, .fields.nom_of, .fields.intitule_formation, .fields.numero_formation
+CREATE TABLE external_opendata_caisse_des_depots_cpf_list (record_id TEXT, date_extract DATE, nom_of TEXT, intitule_formation TEXT, numero_formation TEXT)

--- a/cpf/docker-compose.yml
+++ b/cpf/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+
+services:
+
+  database-cpf-export-local:
+    container_name: database-cpf-export-local
+    image: postgres:14.6-alpine
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+    restart: unless-stopped
+    volumes:
+      - ./create-table.sql:/docker-entrypoint-initdb.d/init.sql
+    ports:
+      - 5432:5432

--- a/cpf/scripts/fetch-cpf-formations.sh
+++ b/cpf/scripts/fetch-cpf-formations.sh
@@ -2,10 +2,22 @@
 
 set -eu
 
-dbclient-fetcher pgsql "$PG_CLIENT_VERSION"
+if command -v dbclient-fetcher &> /dev/null; then
+    dbclient-fetcher pgsql "$PG_CLIENT_VERSION"
+fi
 
-TABLE_NAME='external_opendata_caisse_des_depots_cpf_list'
-DATASET_URL='https://opendata.caissedesdepots.fr/api/records/1.0/search/?dataset=moncompteformation_catalogueformation&rows=2000&q=pix&facet=nom_departement&facet=nom_region&facet=rsrncp&facet=libelle_niveau_sortie_formation&facet=libelle_nsf_1&facet=code_certifinfo&facet=siret&facet=code_region&refine.rsrncp=RS'
+if [ -z "${TABLE_NAME+x}" ]; then
+    TABLE_NAME='external_opendata_caisse_des_depots_cpf_list'
+fi
+
+if [ -z "${DATASET_URL+x}" ]; then
+    DATASET_URL='https://opendata.caissedesdepots.fr/api/records/1.0/search/?dataset=moncompteformation_catalogueformation&q=&rows=2000&facet=nom_departement&facet=nom_region&facet=rsrncp&facet=libelle_niveau_sortie_formation&facet=libelle_nsf_1&facet=libelle_nsf_2&facet=libelle_nsf_3&facet=code_certifinfo&facet=siret&facet=code_region&refine.intitule_certification=Certificat+Pix'
+fi
+
+if [ -z "${DATABASE_URL+x}" ]; then
+    DATABASE_URL='postgres://postgres@localhost:5432/postgres'
+fi
+
 OUTPUT_FILE='/tmp/exportcpf.csv'
 
 psql "$DATABASE_URL" \


### PR DESCRIPTION
## :unicorn: Problème

L'URL utilisée pour récupérer les informations de l'OPEN data de la caisse des dépôts n'a pas les bons filtres, des résultats ne correspondant pas au périmètre des certifications Pix

## :robot: Solution

Modifier l'url par default
Utiliser docker-compose pour les tests en local

## :100: Pour tester

Utiliser la procédure définie dans le README du dossier CPF



