### PR TITLE
[TECH] Utiliser la configuration auto-minor au lieu de la configuration aggressive

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>1024pix/renovate-config:aggressive"],
+  "extends": ["github>1024pix/renovate-config:auto-minor"],
   "enabled": true
 }

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {
-    "node": "18.16.x",
-    "npm": "9.5.x"
+    "node": "18.16.x"
   },
   "scripts": {
     "local:setup-databases": "npm run local:create-databases && npm run local:load-databases",


### PR DESCRIPTION
## :unicorn: Problème

La configuration aggressive est un peu trop violente

## :robot: Solution

Faire de l'automerge seulement sur les versions mineures

## :rainbow: Remarques

Je vire aussi la version de npm qui ne sert à rien

## :100: Pour tester

🟢 
