### PR TITLE
[TECH] Supprimer les attributs inutilisés par Metabase de la table courses

### DIFF
--- a/src/steps/learning-content/index.js
+++ b/src/steps/learning-content/index.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const lcmsClient = require('./lcms-client');
 const databaseHelper = require('../../database-helper');
 
@@ -92,11 +91,8 @@ const tables = [{
   name: 'courses',
   fields: [
     { name: 'name', type: 'text' },
-    { name: 'adaptive', type: 'boolean' },
-    { name: 'competences', type: 'text[]', isArray: true },
-    { name: 'competenceId', type: 'text', extractor: (record) => _.get(record['competences'], 0) },
   ],
-  indexes: ['competenceId'],
+  indexes: [],
 }, {
   name: 'tutorials',
   fields: [

--- a/test/utils/mock-lcms-get-airtable.js
+++ b/test/utils/mock-lcms-get-airtable.js
@@ -364,65 +364,34 @@ function mockLcmsAirtableData() {
     ],
     'courses': [
       {
-        'adaptive': false,
-        'challenges': [
-          'recPbD9nJKGqmopDI',
-          'recpl233mvKQqIzZe',
-          'recqVyHUcAqNEb4qs',
-        ],
         'id': 'rec5UecGJn0kr2odZ',
         'name': 'Démo essentiels',
       },
       {
-        'adaptive': true,
-        'competences': [
-          'recxf7xB2qNV8g5ZT',
-        ],
         'id': 'rec8nO3qZEI41BL5G',
         'name': '2.1 Arts',
       },
       {
-        'adaptive': true,
-        'competences': [
-          'recZ1Gm4rud4zLhbF',
-        ],
         'id': 'recBXNHQwClYhDuwq',
         'name': '1.4 Français',
       },
       {
-        'adaptive': true,
-        'competences': [
-          'recxlJqKdbWHHFZMQ',
-        ],
         'id': 'recbY79yZlzPqK4uB',
         'name': '1.2 Géographie',
       },
       {
-        'adaptive': true,
-        'competences': [
-          'recoVElv3xmVppK5a',
-        ],
         'id': 'recCSTyGclCCJ0iyc',
         'name': '2.2 Philosophie',
       },
       {
-        'adaptive': false,
         'id': 'recKUFCoFaJD87SMi',
         'name': 'Test avec épreuve timée',
       },
       {
-        'adaptive': true,
-        'competences': [
-          'recH9MjIzN54zXlwr',
-        ],
         'id': 'recLFghcJgbaQreUT',
         'name': '1.1 Mathématiques',
       },
       {
-        'adaptive': true,
-        'competences': [
-          'recKxnZJh5dyRCQQn',
-        ],
         'id': 'recNtSu9uN3pjWOQJ',
         'name': '1.3 Histoire',
       },


### PR DESCRIPTION
## :unicorn: Problème
Les attributs adaptive et competences ne sont pas utilisés dans metabase

## :robot: Solution
Les retirer

## :rainbow: Remarques
Ceci est un travail préliminaire car les tests statiques sont migrés hors de airtable et certains attributs sont dépréciés

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
