### PR TITLE
[FEATURE] Ajout de champs dans la réplication des épreuves depuis LCMS (PIX-7820).

### DIFF
--- a/src/steps/learning-content/index.js
+++ b/src/steps/learning-content/index.js
@@ -85,6 +85,12 @@ const tables = [{
     { name: 'genealogy', type: 'text' },
     { name: 'version', type: 'smallint' },
     { name: 'alternativeVersion', type: 'smallint' },
+    { name: 'declinable', type: 'text' },
+    { name: 'proposals', type: 'text' },
+    { name: 'solution', type: 'text' },
+    { name: 'pedagogy', type: 'text' },
+    { name: 'shuffled', type: 'boolean', extractor: (record) => !!record['shuffled'] },
+    { name: 'contextualizedFields', type: 'text []', isArray: true },
   ],
   indexes: ['firstSkillId'],
 }, {


### PR DESCRIPTION
## :unicorn: Problème
Certains champs étaient manquants dans la réplication des épreuves.

## :robot: Solution
Ajouter les champs manquants.

## :rainbow: Remarques
On en profite pour ajouter le nouveau champ `contextualizedFields`.

## :100: Pour tester
Se connecter à la review app en ssh.
Lancer `node -e "require('./src/steps/learning-content').run(require ('./src/config/extract-configuration-from-environment')())"`
Vérifier que la table `challenges` contient les nouvelles colonnes : 
	- declinable
	- shuffled
	- proposals
	- solution
	- pedagogy
	- contextualizedFields
