### PR TITLE
[TECH] Pouvoir configurer le delay sur le retry des jobs

### DIFF
--- a/src/config/extract-configuration-from-environment.js
+++ b/src/config/extract-configuration-from-environment.js
@@ -52,6 +52,7 @@ const extractConfigurationFromEnvironmentVariable = function() {
     SENTRY_MAX_BREADCRUMBS: process.env.SENTRY_MAX_BREADCRUMBS,
     SENTRY_DEBUG: process.env.SENTRY_DEBUG,
     SENTRY_MAX_VALUE_LENGTH: 1000,
+    EXPONENTIAL_RETRY_DELAY: process.env.EXPONENTIAL_RETRY_DELAY || 1000,
     REDIS_URL: process.env.REDIS_URL || 'redis://127.0.0.1:6379',
     NOTIFICATION_URLS,
   };

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -6,7 +6,7 @@ const parisTimezone = 'Europe/Paris';
 
 const jobOptions = {
   attempts: configuration.MAX_RETRY_COUNT,
-  backoff: { type: 'exponential', delay: 100 },
+  backoff: { type: 'exponential', delay: configuration.EXPONENTIAL_RETRY_DELAY },
 };
 
 const repeatableJobOptions = {


### PR DESCRIPTION
## :unicorn: Problème

Le délai avant un nouveau essai de job après un fail est configuré à 100ms, ce qui ne permet notamment pas à lcms de redémarrer. De plus, chaque environnement ayant le même délai, en cas d'erreur les essais se lancent presque en simultané

## :robot: Solution

Rendre ce délai configurable et le passer à 1s minimum.


## :rainbow: Remarques

On change ce délai pour tous les jobs et pas seulement pour le learning content, le maximum du temps ajouté est assez faible pour que l'on puisse se le permettre.

## :100: Pour tester

Vérifier qu'après une erreur le job ne se lance pas 100ms après, mais au moins seconde après : 
Pour cela, sur la RA, configurer une mauvaise URL pour lcms, et lancer la réplication du contenu.

```
npm run restart:learning-content-replication
``` 
