### PR TITLE
[TECH] :sparkles: Supprimer les vues postgres avant de les réinsérer 

### DIFF
--- a/src/steps/backup-restore/index.js
+++ b/src/steps/backup-restore/index.js
@@ -23,7 +23,9 @@ async function dropCurrentObjectsExceptTables(databaseUrl, tableNames) {
   const tableNamesForQuery = tableNames.map((tableName) => `'${tableName}'`).join(',');
   const dropTableQuery = await execStdOut('psql', [ databaseUrl, '--tuples-only', '--command', `select string_agg('drop table "' || tablename || '" CASCADE', '; ') from pg_tables where schemaname = 'public' and tablename not in (${tableNamesForQuery});` ]);
   const dropFunction = await execStdOut('psql', [ databaseUrl, '--tuples-only', '--command', 'select string_agg(\'drop function "\' || proname || \'"\', \'; \') FROM pg_proc pp INNER JOIN pg_roles pr ON pp.proowner = pr.oid WHERE pr.rolname = current_user ' ]);
+  const dropViews = await execStdOut('psql', [ databaseUrl, '--tuples-only', '--command', 'select string_agg(\'drop view "\' || viewname || \'"\', \'; \') FROM pg_views where viewowner=current_user']);
   await exec('psql', [ databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropTableQuery ]);
+  await exec('psql', [ databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropViews ]);
   return exec('psql', [ databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropFunction ]);
 }
 

--- a/test/integration/test-helper.js
+++ b/test/integration/test-helper.js
@@ -10,9 +10,10 @@ async function createBackup(database, databaseConfig, {
   createTablesNotToBeImported = false,
   createForeignKeys = false,
   createFunction = false,
+  createViews = false,
   dropDatabase = true,
 }) {
-  await createAndFillDatabase(database, databaseConfig, { createTablesNotToBeImported, createForeignKeys, createFunction });
+  await createAndFillDatabase(database, databaseConfig, { createTablesNotToBeImported, createForeignKeys, createFunction, createViews });
   const backupFile = await database.createBackup();
   if (dropDatabase) {
     await database.dropDatabase();
@@ -24,6 +25,7 @@ async function createAndFillDatabase(database, databaseConfig, {
   createTablesNotToBeImported = false,
   createForeignKeys = false,
   createFunction = false,
+  createViews = false,
 }) {
   await createTables(database, databaseConfig);
   await fillTables(database, databaseConfig);
@@ -39,10 +41,17 @@ async function createAndFillDatabase(database, databaseConfig, {
   if (createFunction) {
     await createTestFunction(database);
   }
+  if (createViews) {
+    await createCustomViews(database);
+  }
 }
 
 async function createTableToBeBaseForView(database) {
   await database.runSql('CREATE TABLE "schooling-registrations" (id INT NOT NULL PRIMARY KEY)');
+}
+
+async function createCustomViews(database) {
+  await database.runSql('CREATE VIEW "custom-view" AS SELECT schemaname,tablename FROM pg_catalog.pg_tables;');
 }
 
 async function createTablesThatMayNotBeRestored(database) {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, si une vue créee n'est pas liée à une table supprimée de la BDD (ex: vue sur des tables "pg_"), elle n'est pas supprimée automatiquement à chaque réplication, et la restauration tente de la réinserer, provoquant un conflit 

## :robot: Solution
Supprimer uniquement les vues créées par l'utilisateur de réplication sur la BDD, et pas celles créées par les extensions etc ...

## :rainbow: Remarques
On commence à avoir besoin de vue custom pour gérer le monitoring

## :100: Pour tester
🟢 
En RA, créer une vue dans la bdd source avec un pgsql-console, et lancer plusieurs fois la réplication :
`run  "npm run restart:full-replication"`
