### PR TITLE
[TECH] Monter la version de l'image postgresql

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
   test:
     docker:
       - image: cimg/node:20.8.1
-      - image: postgres:14.8-alpine
+      - image: postgres:14.10-alpine
         environment:
           POSTGRES_USER: postgres
           POSTGRES_HOST_AUTH_METHOD: trust

--- a/cpf/docker-compose.yml
+++ b/cpf/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   database-cpf-export-local:
     container_name: database-cpf-export-local
-    image: postgres:14.8-alpine
+    image: postgres:14.10-alpine
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   database:
     container_name: database
-    image: postgres:14.8-alpine
+    image: postgres:14.10-alpine
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
     restart: unless-stopped


### PR DESCRIPTION
## :unicorn: Problème
Une nouvelle version des addons postgresql et redis est proposée par Scalingo et la montée de version va être effectuée. Cependant, les images docker sont encore sur les anciennes versions.

## :robot: Solution
- Mettre à jour la version de l'image postgresql de la version 14.8 à la version 14.10
- Version de l'image redis déjà à jour