### PR TITLE
[BUGFIX] :bug: Corriger le filtrage des tables lors de la restoration (PIX-11598)

### DIFF
--- a/test/unit/steps/backup-restore/index_test.js
+++ b/test/unit/steps/backup-restore/index_test.js
@@ -1,7 +1,93 @@
 const { expect, sinon } = require('../../../test-helper');
+const { filterObjectLines } = require('../../../../src/steps/backup-restore');
 const proxyquire = require('proxyquire').noPreserveCache();
 
 describe('Unit | steps | Backup restore | index.js', () => {
+  describe('#filterObjectLines', ()=>{
+    context('using default configuration', async () => {
+      it('should only remove comments and FK from file', async () => {
+      // given
+        objectLines = [
+          '4688; 0 0 COMMENT - EXTENSION pgcrypto',
+          '2; 3079 38970 EXTENSION - pgcrypto',
+          '4344; 2606 38649 FK CONSTRAINT public account-recovery-demands account-recovery-demands_organizationlearnerid_foreign postgres',
+          '4344; 2606 38649 FK CONSTRAINT public account-recovery-demands account-recovery-demands_organizationlearnerid_foreign postgres',
+          '4344; 2606 38649 SEQUENCE SET public answers postgres',
+          '4344; 2606 38649 SEQUENCE SET public element-answers postgres',
+          '4344; 2606 38649 SEQUENCE SET public answers-corrected postgres',
+          '4344; 2606 38649 TABLE public answers postgres',
+          '4344; 2606 38649 TABLE public element-answers postgres',
+          '4344; 2606 38649 TABLE public assessment-results postgres',
+          '3264; 1259 16832 INDEX element_answers_id_index postgres',
+          '3264; 1259 16832 INDEX answers_id_index postgres',
+        ];
+        // when
+        const result = filterObjectLines(objectLines, {});
+
+        // then
+        expect(result).to.deep.equal([
+          '2; 3079 38970 EXTENSION - pgcrypto',
+          '4344; 2606 38649 SEQUENCE SET public answers postgres',
+          '4344; 2606 38649 SEQUENCE SET public element-answers postgres',
+          '4344; 2606 38649 SEQUENCE SET public answers-corrected postgres',
+          '4344; 2606 38649 TABLE public answers postgres',
+          '4344; 2606 38649 TABLE public element-answers postgres',
+          '4344; 2606 38649 TABLE public assessment-results postgres',
+          '3264; 1259 16832 INDEX element_answers_id_index postgres',
+          '3264; 1259 16832 INDEX answers_id_index postgres',
+        ]);
+      });
+    });
+
+    it('should only filter specified table', async () => {
+      // given
+      configuration = {
+        RESTORE_FK_CONSTRAINTS: 'false',
+        BACKUP_MODE: { 'element-answers': 'incremental' },
+      };
+
+      objectLines = [
+        'SEQUENCE SET public answers postgres',
+        'SEQUENCE SET public element-answers postgres',
+        'SEQUENCE SET public answers-corrected postgres',
+        'TABLE public answers postgres',
+        'TABLE public element-answers postgres',
+        'TABLE public assessment-results postgres',
+        'INDEX element_answers_id_index postgres',
+        'INDEX answers_id_index postgres',
+      ];
+      // when
+      const result = filterObjectLines(objectLines, configuration);
+
+      // then
+      expect(result).to.deep.equal([
+        'SEQUENCE SET public answers postgres',
+        'SEQUENCE SET public answers-corrected postgres',
+        'TABLE public answers postgres',
+        'TABLE public assessment-results postgres',
+        'INDEX answers_id_index postgres',
+      ]);
+    });
+
+    it('should keep fk constraints', async () => {
+      // given
+      configuration = {
+        RESTORE_FK_CONSTRAINTS: 'true',
+        BACKUP_MODE: {},
+      };
+      objectLines = [
+        '4344; 2606 38649 INDEX public users_email_lower postgres',
+        '4344; 2606 38649 FK CONSTRAINT public account-recovery-demands account-recovery-demands_organizationlearnerid_foreign postgres',
+        '4344; 2606 38649 FK CONSTRAINT public account-recovery-demands account_recovery_demands_userid_foreign postgres',
+        '4344; 2606 38649 FK CONSTRAINT public activities activities_assessmentid_foreign postgres',
+      ];
+      // when
+      const result = filterObjectLines(objectLines, configuration);
+
+      // then
+      expect(result).to.deep.equal(objectLines);
+    });
+  });
 
   describe('#createBackup', () => {
     let execStub;
@@ -118,5 +204,4 @@ describe('Unit | steps | Backup restore | index.js', () => {
     });
 
   });
-
 });


### PR DESCRIPTION
## :unicorn: Problème

Lors de la restoration, le filtrage actuel supprime les tables via des regex qui sont trop greedy. 
Par exemple, si l'on souhaite supprimer une table `toto`, les objets suivant sont bien exclus : 

```
TABLE toto
SEQUENCE toto_seq
```
Mais les objets suivants sont également supprimés : 

```
TABLE super-toto
SEQUENCE super_toto_seq
```

## :robot: Solution

Améliorer le filtrage pour ne matcher que les tables en question

## 😋 Remarques 

L'outil fait 2 fois "la même chose", lors du `dump` il supprime les tables répliquées de façon incrémentale, mais comme l'option `--exclude-table` ne supprime pas tout (`SEQUENCE`, …) alors un filtre est aussi fait au moment du `restore`.  

Nous avons constaté que le `dump` fait dans les test n'a pas le comportement d'exclusion fait dans l'implémentation. Cela est problématique car du code a été écrit dans l'implémentation, pour palier à ce manquement. 

# :100: Pour tester

