### PR TITLE
[BUGFIX] Corriger la réplication en supprimant les enums

### DIFF
--- a/src/steps/backup-restore/index.js
+++ b/src/steps/backup-restore/index.js
@@ -22,9 +22,11 @@ async function dropCurrentObjects(configuration) {
 async function dropCurrentObjectsExceptTables(databaseUrl, tableNames) {
   const tableNamesForQuery = tableNames.map((tableName) => `'${tableName}'`).join(',');
   const dropTableQuery = await execStdOut('psql', [ databaseUrl, '--tuples-only', '--command', `select string_agg('drop table "' || tablename || '" CASCADE', '; ') from pg_tables where schemaname = 'public' and tablename not in (${tableNamesForQuery});` ]);
+  const dropEnumQuery = await execStdOut('psql', [ databaseUrl, '--tuples-only', '--command', 'select string_agg(\'drop type "\' || typname || \'"\', \'; \') from (select distinct t.typname from pg_type t join pg_enum e on t.oid = e.enumtypid) as typenames;' ]);
   const dropFunction = await execStdOut('psql', [ databaseUrl, '--tuples-only', '--command', 'select string_agg(\'drop function "\' || proname || \'"\', \'; \') FROM pg_proc pp INNER JOIN pg_roles pr ON pp.proowner = pr.oid WHERE pr.rolname = current_user ' ]);
   const dropViews = await execStdOut('psql', [ databaseUrl, '--tuples-only', '--command', 'select string_agg(\'drop view "\' || viewname || \'"\', \'; \') FROM pg_views where viewowner=current_user']);
   await exec('psql', [ databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropTableQuery ]);
+  await exec('psql', [ databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropEnumQuery ]);
   await exec('psql', [ databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropViews ]);
   return exec('psql', [ databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropFunction ]);
 }


### PR DESCRIPTION
## :unicorn: Problème
La team prescription (merci à eux ;)) à ajouter une énumération `organization-imports-statuses` pour la table `organization-imports`. L'ajout de cet enum casse la réplication car nous ne la supprimons pas lors de la phase de suppression des tables, views et functions.  

## :robot: Solution
Supprimer les enums avant de restaurer le dump.

## :rainbow: Remarques
Il existe une autre enum `job_state` dans la table `pix-datawarehouse-production` qui semble être lié à pgBoss. Actuellement les tables pgBoss ne sont pas répliquées donc nous pensons qu'il n'est pas dérangeant de supprimer aussi cet enum.

## :100: Pour tester
Tester la réplication sur la RA
