### PR TITLE
[TECH] Ne plus exposer le champ déprécié "title" de la table "tubes" (PIX-11631)

### DIFF
--- a/src/steps/learning-content/index.js
+++ b/src/steps/learning-content/index.js
@@ -31,7 +31,6 @@ const tables = [{
   name: 'tubes',
   fields: [
     { name: 'name', type: 'text' },
-    { name: 'title', type: 'text' },
     { name: 'practicalTitle', type: 'text', extractor: (record) => record.practicalTitle_i18n.fr },
     { name: 'practicalDescription', type: 'text', extractor: (record) => record.practicalDescription_i18n.fr },
     { name: 'competenceId', type: 'text', isArray: false },


### PR DESCRIPTION
## :unicorn: Problème
Côté référentiel Airtable, le champ `Titre` convertit en `title` dans la table des `Sujets` `tubes` est déprécié.
On décide de ne plus l'exposer dans la réplication.

## :robot: Solution
Retirer ce champ de la liste des champs à exposer

## :rainbow: Remarques
Le champ n'était pas dans les tests auto donc pas de tests à modifier

## :100: Pour tester

