### PR TITLE
[FEATURE] Rajouter les champs spoil pour les acquis (PIX-11739)

### DIFF
--- a/src/steps/learning-content/index.js
+++ b/src/steps/learning-content/index.js
@@ -49,6 +49,10 @@ const tables = [{
     { name: 'tutorialIds', type: 'text []', isArray: true },
     { name: 'learningMoreTutorialIds', type: 'text []', isArray: true },
     { name: 'internationalisation', type: 'text' },
+    { name: 'Spoil_focus', type: 'text' },
+    { name: 'Spoil_variabilisation', type: 'text []', isArray: true },
+    { name: 'Spoil_mauvaisereponse', type: 'text []', isArray: true },
+    { name: 'Spoil_nouvelacquis', type: 'text' },
   ],
   indexes: ['tubeId'],
 }, {


### PR DESCRIPTION
## :unicorn: Problème
Des champs spoil ont été ajoutés à Airtable, à pix-editor, mais ne sont pas remontés ici pour metabase

## :robot: Solution
Ajouter les champs dans nos skills pour pouvoir les lire sur metabase

## :rainbow: Remarques
Tests (unitaire et intégration ?) à faire ?

## :100: Pour tester
Voir dans metabase si les champs apparaissent bien dans une requête de skills.
