### PR TITLE
[TECH] Changer la configuration dépréciée auto-minor de renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>1024pix/renovate-config:auto-minor"],
+  "extends": ["github>1024pix/renovate-config:default"],
   "enabled": true
 }


### PR DESCRIPTION
## :unicorn: Problème
La configuration actuelle de renovate est `auto-minor`. Or cette configuration est dépréciée. 

## :robot: Solution
Utiliser la configuration par défaut à la place.

## :rainbow: Remarques
La configuration par défaut contient notamment l'alignement des versions des postgres et redis des fichiers docker-compose avec les versions disponibles sur Scalingo. 