### PR TITLE
[FEATURE] Remonter le champ "urlsToConsult" des épreuves dans la base de réplication (PIX-12440)

### DIFF
--- a/src/steps/learning-content/index.js
+++ b/src/steps/learning-content/index.js
@@ -96,6 +96,7 @@ const tables = [{
     { name: 'pedagogy', type: 'text' },
     { name: 'shuffled', type: 'boolean', extractor: (record) => !!record['shuffled'] },
     { name: 'contextualizedFields', type: 'text []', isArray: true },
+    { name: 'urlsToConsult', type: 'text []', isArray: true },
   ],
   indexes: ['firstSkillId'],
 }, {


### PR DESCRIPTION
## :unicorn: Problème
Le champ urlsToConsult des challenges est présent sur le endpoint LCMS, mais n'est pas copié dans la base de répli.

## :robot: Solution
Copier le champ dans la base de répli.

## :rainbow: Remarques
N/A

## :100: Pour tester
Résultat sur la RA OK :
```
pix_datawar_6346=> \d challenges
                               Table "public.challenges"
          Column           |           Type           | Collation | Nullable | Default 
---------------------------+--------------------------+-----------+----------+---------
 id                        | text                     |           | not null | 
 instruction               | text                     |           |          | 
 status                    | text                     |           |          | 
 type                      | text                     |           |          | 
 timer                     | smallint                 |           |          | 
 autoReply                 | boolean                  |           | not null | 
 skillId                   | text                     |           |          | 
 skillIds                  | text[]                   |           |          | 
 skillCount                | smallint                 |           |          | 
 firstSkillId              | text                     |           |          | 
 secondSkillId             | text                     |           |          | 
 thirdSkillId              | text                     |           |          | 
 languages                 | text[]                   |           |          | 
 embedUrl                  | text                     |           |          | 
 hasEmbedUrl               | boolean                  |           | not null | 
 alternativeInstruction    | text                     |           |          | 
 hasAlternativeInstruction | boolean                  |           | not null | 
 area                      | text                     |           |          | 
 focus                     | boolean                  |           | not null | 
 explicativeResponse       | text                     |           |          | 
 delta                     | numeric                  |           |          | 
 alpha                     | numeric                  |           |          | 
 createdAt                 | timestamp with time zone |           |          | 
 validatedAt               | timestamp with time zone |           |          | 
 archivedAt                | timestamp with time zone |           |          | 
 madeObsoleteAt            | timestamp with time zone |           |          | 
 accessibility1            | text                     |           |          | 
 accessibility2            | text                     |           |          | 
 spoil                     | text                     |           |          | 
 responsive                | text                     |           |          | 
 genealogy                 | text                     |           |          | 
 version                   | smallint                 |           |          | 
 alternativeVersion        | smallint                 |           |          | 
 declinable                | text                     |           |          | 
 proposals                 | text                     |           |          | 
 solution                  | text                     |           |          | 
 pedagogy                  | text                     |           |          | 
 shuffled                  | boolean                  |           | not null | 
 contextualizedFields      | text[]                   |           |          | 
 urlsToConsult             | text[]                   |           |          | 
```