### PR TITLE
[FEATURE] Permettre d'ajouter une en-tête d'authorisation aux notifications (PIX-12873).

### DIFF
--- a/src/config/extract-configuration-from-environment.js
+++ b/src/config/extract-configuration-from-environment.js
@@ -17,7 +17,7 @@ const loadEnvironmentVariableFromFileIfNotOnPaas = function() {
 
 const extractConfigurationFromEnvironmentVariable = function() {
   let BACKUP_MODE;
-  let NOTIFICATION_URLS;
+  let NOTIFICATIONS;
 
   try {
     BACKUP_MODE = process.env.BACKUP_MODE ? JSON.parse(process.env.BACKUP_MODE) : {};
@@ -26,7 +26,7 @@ const extractConfigurationFromEnvironmentVariable = function() {
     throw e;
   }
   try {
-    NOTIFICATION_URLS = process.env.NOTIFICATION_URLS ? JSON.parse(process.env.NOTIFICATION_URLS) : [];
+    NOTIFICATIONS = process.env.NOTIFICATIONS ? JSON.parse(process.env.NOTIFICATIONS) : [];
   } catch (e) {
     logger.error('NOTIFICATION_URLS should be a JSON value');
     throw e;
@@ -55,7 +55,7 @@ const extractConfigurationFromEnvironmentVariable = function() {
     SENTRY_MAX_VALUE_LENGTH: 1000,
     EXPONENTIAL_RETRY_DELAY: process.env.EXPONENTIAL_RETRY_DELAY || 1000,
     REDIS_URL: process.env.REDIS_URL || 'redis://127.0.0.1:6379',
-    NOTIFICATION_URLS,
+    NOTIFICATIONS,
   };
 };
 

--- a/src/steps/notification.js
+++ b/src/steps/notification.js
@@ -16,7 +16,13 @@ async function run(configuration) {
 
 async function notifyUrl(notification) {
   try {
-    const response = await axios.post(notification.url);
+    const isAuthenticated = notification.token !== undefined;
+    const headers = !isAuthenticated ? {} : {
+      Authorization: notification.token,
+    };
+    const response = await axios.post(notification.url, {}, {
+      headers,
+    });
     return response;
   } catch (httpErr) {
     logger.error(`Error on POST request to ${notification.url}`);

--- a/src/steps/notification.js
+++ b/src/steps/notification.js
@@ -6,20 +6,20 @@ import { logger } from '../logger.js';
 async function run(configuration) {
   logger.info('Start notification');
 
-  for (const url of configuration.NOTIFICATION_URLS) {
-    logger.info(`Notify ${url}`);
-    await notifyUrl(url);
+  for (const notification of configuration.NOTIFICATION_URLS) {
+    logger.info(`Notify ${notification.url}`);
+    await notifyUrl(notification);
   }
 
   logger.info('Notification done');
 }
 
-async function notifyUrl(url) {
+async function notifyUrl(notification) {
   try {
-    const response = await axios.post(url);
+    const response = await axios.post(notification.url);
     return response;
   } catch (httpErr) {
-    logger.error(`Error on POST request to ${url}`);
+    logger.error(`Error on POST request to ${notification.url}`);
     throw (httpErr);
   }
 }

--- a/src/steps/notification.js
+++ b/src/steps/notification.js
@@ -6,7 +6,7 @@ import { logger } from '../logger.js';
 async function run(configuration) {
   logger.info('Start notification');
 
-  for (const notification of configuration.NOTIFICATION_URLS) {
+  for (const notification of configuration.NOTIFICATIONS) {
     logger.info(`Notify ${notification.url}`);
     await notifyUrl(notification);
   }

--- a/test/integration/steps/notification_test.js
+++ b/test/integration/steps/notification_test.js
@@ -7,8 +7,8 @@ describe('Integration | Steps | notification.js', () => {
     it('should call all notification urls', async function () {
       const configuration = {
         NOTIFICATION_URLS: [
-          'http://example.net/webhook1',
-          'http://example.net/webhook2',
+          { url: 'http://example.net/webhook1' },
+          { url: 'http://example.net/webhook2' },
         ]
       };
 

--- a/test/integration/steps/notification_test.js
+++ b/test/integration/steps/notification_test.js
@@ -1,0 +1,30 @@
+import { expect, catchErr, nock } from '../../test-helper.js';
+import {run} from '../../../src/steps/notification.js';
+
+
+describe('Integration | Steps | notification.js', () => {
+  describe('run', function() {
+    it('should call all notification urls', async function () {
+      const configuration = {
+        NOTIFICATION_URLS: [
+          'http://example.net/webhook1',
+          'http://example.net/webhook2',
+        ]
+      };
+
+      const scopeWebhook1 = nock('http://example.net')
+        .post('/webhook1')
+        .reply(200, {});
+
+      const scopeWebhook2 = nock('http://example.net')
+        .post('/webhook2')
+        .reply(200, {});
+
+
+      await run(configuration);
+
+      expect(scopeWebhook1.isDone()).to.be.true;
+      expect(scopeWebhook2.isDone()).to.be.true;
+    });
+  });
+});

--- a/test/integration/steps/notification_test.js
+++ b/test/integration/steps/notification_test.js
@@ -1,15 +1,14 @@
-import { expect, catchErr, nock } from '../../test-helper.js';
-import {run} from '../../../src/steps/notification.js';
+import { expect, nock } from '../../test-helper.js';
+import { run } from '../../../src/steps/notification.js';
 
-
-describe('Integration | Steps | notification.js', () => {
+describe('Integration | Steps | notification.js', function() {
   describe('run', function() {
-    it('should call all notification urls', async function () {
+    it('should call all notification urls and use auth token when provided', async function() {
       const configuration = {
         NOTIFICATION_URLS: [
           { url: 'http://example.net/webhook1' },
-          { url: 'http://example.net/webhook2' },
-        ]
+          { url: 'http://example.net/webhook2', token: 'mon-super-token' },
+        ],
       };
 
       const scopeWebhook1 = nock('http://example.net')
@@ -18,8 +17,8 @@ describe('Integration | Steps | notification.js', () => {
 
       const scopeWebhook2 = nock('http://example.net')
         .post('/webhook2')
+        .matchHeader('Authorization', 'mon-super-token')
         .reply(200, {});
-
 
       await run(configuration);
 

--- a/test/integration/steps/notification_test.js
+++ b/test/integration/steps/notification_test.js
@@ -5,7 +5,7 @@ describe('Integration | Steps | notification.js', function() {
   describe('run', function() {
     it('should call all notification urls and use auth token when provided', async function() {
       const configuration = {
-        NOTIFICATION_URLS: [
+        NOTIFICATIONS: [
           { url: 'http://example.net/webhook1' },
           { url: 'http://example.net/webhook2', token: 'mon-super-token' },
         ],


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous pouvons appeler que des webhooks qui ne sont pas authentifiés.

## :robot: Solution
Permettre l'ajout d'un token 

## :rainbow: Remarques
Le format de la variable d'environnement : 
```shell
NOTIFICATION_URLS=['https://example.net']
``` 
Devient : 

```shell
NOTIFICATION_URLS=[{ url: 'https://example.net', token: 'toto' }, ]
``` 

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
