### PR TITLE
[TECH] Nettoyage des données de l'enquête anti-spoil (PIX-13811)

### DIFF
--- a/src/steps/learning-content/index.js
+++ b/src/steps/learning-content/index.js
@@ -49,10 +49,6 @@ const tables = [{
     { name: 'tutorialIds', type: 'text []', isArray: true },
     { name: 'learningMoreTutorialIds', type: 'text []', isArray: true },
     { name: 'internationalisation', type: 'text' },
-    { name: 'spoil_focus', type: 'text' },
-    { name: 'spoil_variabilisation', type: 'text []', isArray: true },
-    { name: 'spoil_mauvaisereponse', type: 'text []', isArray: true },
-    { name: 'spoil_nouvelacquis', type: 'text' },
   ],
   indexes: ['tubeId'],
 }, {


### PR DESCRIPTION
## :unicorn: Problème
L'enquête anti-spoil étant terminée, nous pouvons arrêter de répliquer les données de celle-ci.

## :robot: Solution
Suppression de la réplication des champs `spoil_*`.

## :rainbow: Remarques
RAS

## :100: Pour tester
RAS
