### PR TITLE
[BUGFIX] Remettre les options d'execa pour la réplication incrémentale

### DIFF
--- a/src/steps/incremental.js
+++ b/src/steps/incremental.js
@@ -61,8 +61,14 @@ async function run(configuration) {
       `\\copy ${escapeSQLIdentifier(table.name)} from stdin`,
     ];
 
-    const { stdout: copyStdout } = await execa `psql ${copyToStdOutArgs}`
-      .pipe `psql ${copyFromStdInArgs}`;
+    const subprocess = execa({
+      all: true, // join stdout and stderr
+    }) `psql ${copyFromStdInArgs}`;
+    const { stdout: copyStdout } = await execa({
+      stdin: 'ignore', stdout: 'pipe', stderr: 'inherit',
+      buffer: false, // disable execa's buffering otherwise it interferes with the transfer
+    }) `psql ${copyToStdOutArgs}`
+      .pipe(subprocess);
 
     logger.info(`${table.name} table copy returned: ` + copyStdout);
 


### PR DESCRIPTION
## :unicorn: Problème
Lors de la mise à jour de la librairie `execa`, les options qui étaient passées en paramètre n'ont pas été conservées pour la réplication incrémentale. Cela a entraîné des erreurs d'Out of Memory lors de la réplication.  

## :robot: Solution
Remettre les options d'execa pour la réplication incrémentale

## :rainbow: Remarques
Le paramètre le plus important ici semble être le `buffer: false` sur le processus de `COPY FROM`.

## :100: Pour tester
Pas simple de tester la réplication incrémentale avec un volume de données comparable à la production. 
