### PR TITLE
[FEATURE] Modifier la valeur des mots de passe suite à la restauration

### DIFF
--- a/src/steps/backup-restore/enrichment.js
+++ b/src/steps/backup-restore/enrichment.js
@@ -5,7 +5,7 @@ import toPairs from 'lodash/toPairs.js';
 import { runDBOperation } from '../../database-helper.js';
 import { logger } from '../../logger.js';
 
-async function add(configuration) {
+async function createIndexes(configuration) {
   await runDBOperation(async (client) => {
     const tablesToNotBeEnriched = _getTablesToNotBeEnriched(configuration);
     if (!tablesToNotBeEnriched.includes('knowledge-elements')) {
@@ -25,11 +25,22 @@ async function add(configuration) {
       await client.query('CREATE INDEX "answers_challengeId_idx" on "answers" ("challengeId")');
       logger.info('CREATE INDEX "answers_challengeId_idx" - Ended');
     }
-
     if (!tablesToNotBeEnriched.includes('users')) {
       logger.info('CREATE INDEX "users_createdAt_idx" - Started');
       await client.query('CREATE INDEX "users_createdAt_idx" on "users" (cast("createdAt" AT TIME ZONE \'UTC+1\' as date) DESC)');
       logger.info('CREATE INDEX "users_createdAt_idx" - Ended');
+    }
+  }, configuration);
+}
+
+async function updateData(configuration) {
+  await runDBOperation(async (client) => {
+    const tablesToNotBeEnriched = _getTablesToNotBeEnriched(configuration);
+
+    if (!tablesToNotBeEnriched.includes('authentication-methods')) {
+      logger.info('UPDATE "authentication-methods" - Started');
+      await client.query('UPDATE "authentication-methods" SET "authenticationComplement" = jsonb_set("authenticationComplement", \'{password}\', to_jsonb(rpad(left(("authenticationComplement" -> \'password\')::text, 8), 60, \'x\'))) WHERE "identityProvider"=\'PIX\'');
+      logger.info('UPDATE "authentication-methods" - Ended');
     }
   }, configuration);
 }
@@ -42,5 +53,6 @@ function _getTablesToNotBeEnriched(configuration) {
 }
 
 export {
-  add,
+  createIndexes,
+  updateData,
 };

--- a/src/steps/backup-restore/index.js
+++ b/src/steps/backup-restore/index.js
@@ -109,7 +109,8 @@ async function dropObjectAndRestoreBackup(backupFile, configuration) {
 async function addEnrichment(configuration) {
   try {
     logger.info('enrichment.add - Started');
-    await enrichment.add(configuration);
+    await enrichment.createIndexes(configuration);
+    await enrichment.updateData(configuration);
     logger.info('enrichment.add - Ended');
   } catch (error) {
     logger.error(error);

--- a/test/integration/steps/backup-restore/enrichment_test.js
+++ b/test/integration/steps/backup-restore/enrichment_test.js
@@ -9,7 +9,7 @@ const DATABASE_URL = process.env.TARGET_DATABASE_URL || 'postgres://pix@localhos
 import { createAndFillDatabase } from '../../test-helper.js';
 import { Database } from '../../../utils/database.js';
 
-import { add } from '../../../../src/steps/backup-restore/enrichment.js';
+import { createIndexes, updateData } from '../../../../src/steps/backup-restore/enrichment.js';
 
 describe('Integration | Steps | Backup restore | enrichment.js', function() {
 
@@ -28,7 +28,7 @@ describe('Integration | Steps | Backup restore | enrichment.js', function() {
     databaseConfig.databaseUrl = `${databaseConfig.serverUrl}/${databaseConfig.databaseName}`;
   });
 
-  describe('add', function() {
+  describe('createIndexes', function() {
 
     context('according to environment variables', function() {
       let database;
@@ -67,7 +67,7 @@ describe('Integration | Steps | Backup restore | enrichment.js', function() {
           const BACKUP_MODE = tables.reduce((tablesObject, tableName) =>
             ({ ...tablesObject, [tableName]: mode }), {});
           const configuration = { BACKUP_MODE, DATABASE_URL: databaseConfig.databaseUrl };
-          await add(configuration);
+          await createIndexes(configuration);
 
           // then
           const KEIndexCount = parseInt(await database.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'knowledge-elements_createdAt_idx\''));
@@ -87,4 +87,75 @@ describe('Integration | Steps | Backup restore | enrichment.js', function() {
     });
   });
 
+  describe('updateData', function() {
+    describe('when table is not backup/restored', function() {
+      let database;
+
+      after(function() {
+        database.dropDatabase();
+      });
+
+      it('should not update the table', async function() {
+        // given
+        database = await Database.create(databaseConfig);
+        await createAndFillDatabase(database, databaseConfig, { createTablesNotToBeImported: true });
+        const BACKUP_MODE = { 'authentication-methods': 'none' };
+        const configuration = { BACKUP_MODE, DATABASE_URL: databaseConfig.databaseUrl };
+
+        // when
+        await updateData(configuration);
+
+        // then
+        const passwordsString = await database.runSql('SELECT "authenticationComplement" -> \'password\' FROM "authentication-methods"');
+        expect(passwordsString.match(/\$.*\$.*\$x+/g)).to.be.null;
+      });
+    });
+
+    describe('when the provider is not PIX', function() {
+      let database;
+
+      after(function() {
+        database.dropDatabase();
+      });
+
+      it('should not update the password', async function() {
+        // given
+        database = await Database.create(databaseConfig);
+        await createAndFillDatabase(database, databaseConfig, { createTablesNotToBeImported: true });
+        const otherProviderPassword = '$2a$12$R9h/cIPz0gi.URNNX3kh2OPST9/PgBkqquzi.Ss7KIUgO2t0jWMUW';
+        await database.runSql(`INSERT INTO "authentication-methods"(id, "identityProvider", "authenticationComplement") VALUES (3, 'OTHER',  '{"password":"${otherProviderPassword}"}'::jsonb)`);
+        const configuration = { BACKUP_MODE: {}, DATABASE_URL: databaseConfig.databaseUrl };
+
+        // when
+        await updateData(configuration);
+
+        // then
+        const passwordsString = await database.runSql('SELECT "authenticationComplement" -> \'password\' FROM "authentication-methods" WHERE "identityProvider" = \'OTHER\'');
+        expect(passwordsString).to.equal(`"${otherProviderPassword}"`);
+      });
+    });
+
+    describe('when table is backup/restored', function() {
+      let database;
+
+      after(function() {
+        database.dropDatabase();
+      });
+
+      it('should update the passwords', async function() {
+        // given
+        database = await Database.create(databaseConfig);
+        await createAndFillDatabase(database, databaseConfig, { createTablesNotToBeImported: true });
+        const configuration = { BACKUP_MODE: {}, DATABASE_URL: databaseConfig.databaseUrl };
+
+        // when
+        await updateData(configuration);
+
+        // then
+        const passwordsString = await database.runSql('SELECT "authenticationComplement" -> \'password\' FROM "authentication-methods"');
+        expect(passwordsString.match(/\$.*\$.*\$x+/g).length).to.equal(2);
+      });
+    });
+
+  });
 });

--- a/test/integration/test-helper.js
+++ b/test/integration/test-helper.js
@@ -72,6 +72,9 @@ async function createTablesThatMayNotBeRestored(database) {
     );`);
   await database.runSql('INSERT INTO "knowledge-element-snapshots"  (id, "userId", "snappedAt", "snapshot") VALUES (1, 2, CURRENT_TIMESTAMP, \'{"id": "3"}\'::jsonb)');
   await database.runSql('CREATE INDEX "knowledge_elements_userid_index" ON "knowledge-elements" ("userId")');
+  await database.runSql('CREATE TABLE "authentication-methods" (id int NOT NULL PRIMARY KEY, "identityProvider" varchar(255) not null, "authenticationComplement" jsonb not null)');
+  await database.runSql('INSERT INTO "authentication-methods" (id, "identityProvider", "authenticationComplement") VALUES (1, \'PIX\', \'{"password":"$2a$05$hHah7.eUI87YP7NrkuZ9YO0/inHOD.JxJoFvaGiZKfffBIdH12345"}\'::jsonb)');
+  await database.runSql('INSERT INTO "authentication-methods" (id, "identityProvider", "authenticationComplement") VALUES (2, \'PIX\', \'{"password":"$2a$05$hHah7.eUI87YP7NrkuZ9YO0/inHOD.JxJoFvaGiZKfffBIdH56789"}\'::jsonb)');
 }
 
 async function createTableWithForeignKey(database, databaseConfig) {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, bien que cryptés, les mots de passes sont accessibles dans la base de réplication interne.

## :robot: Solution
Ajouter une phase de mise à jour du mot de passe avant de cacher leur valeur.

## :rainbow: Remarques
Nous conservons les premiers paramètres du mot de passe afin de conserver l'identifiant de l'algo de hachage et le nombre d'itérations permettant de générer le mot de passe (`$2a$10`) puis nous complétons avec le caractère "x".