### PR TITLE
[BUGFIX] Supprimer le guillemet en trop lors de la mise à jour du mot de passe dans la table authentication-methods

### DIFF
--- a/src/steps/backup-restore/enrichment.js
+++ b/src/steps/backup-restore/enrichment.js
@@ -39,7 +39,7 @@ async function updateData(configuration) {
 
     if (!tablesToNotBeEnriched.includes('authentication-methods')) {
       logger.info('UPDATE "authentication-methods" - Started');
-      await client.query('UPDATE "authentication-methods" SET "authenticationComplement" = jsonb_set("authenticationComplement", \'{password}\', to_jsonb(rpad(left(("authenticationComplement" -> \'password\')::text, 8), 60, \'x\'))) WHERE "identityProvider"=\'PIX\'');
+      await client.query('UPDATE "authentication-methods" SET "authenticationComplement" = jsonb_set("authenticationComplement", \'{password}\', to_jsonb(rpad(substring(("authenticationComplement" -> \'password\')::text, 2, 7), 60, \'x\'))) WHERE "identityProvider"=\'PIX\'');
       logger.info('UPDATE "authentication-methods" - Ended');
     }
   }, configuration);


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, lors de la réplication, nous modifions les mots de passe de la table `authentication-methods`. Cependant, un guillemet, en trop, est conservé.  

## :robot: Solution
Supprimer le guillemet en trop lors de la mise à jour du mot de passe.