### PR TITLE
[TECH] Améliorer les performances de la réplication

### DIFF
--- a/src/steps/backup-restore/enrichment.js
+++ b/src/steps/backup-restore/enrichment.js
@@ -39,7 +39,7 @@ async function updateData(configuration) {
 
     if (!tablesToNotBeEnriched.includes('authentication-methods')) {
       logger.info('UPDATE "authentication-methods" - Started');
-      await client.query('UPDATE "authentication-methods" SET "authenticationComplement" = jsonb_set("authenticationComplement", \'{password}\', to_jsonb(rpad(substring(("authenticationComplement" -> \'password\')::text, 2, 7), 60, \'x\'))) WHERE "identityProvider"=\'PIX\'');
+      await client.query('UPDATE "authentication-methods" SET "authenticationComplement" = jsonb_set("authenticationComplement", \'{password}\', to_jsonb(substring(("authenticationComplement" -> \'password\')::text, 2, 7))) WHERE "identityProvider"=\'PIX\'');
       logger.info('UPDATE "authentication-methods" - Ended');
     }
   }, configuration);

--- a/src/steps/backup-restore/index.js
+++ b/src/steps/backup-restore/index.js
@@ -22,12 +22,12 @@ async function dropCurrentObjects(configuration) {
 async function dropCurrentObjectsExceptTables(databaseUrl, tableNames) {
   const tableNamesForQuery = tableNames.map((tableName) => `'${tableName}'`).join(',');
   const dropTableQuery = await execStdOut('psql', [ databaseUrl, '--tuples-only', '--command', `select string_agg('drop table "' || tablename || '" CASCADE', '; ') from pg_tables where schemaname = 'public' and tablename not in (${tableNamesForQuery});` ]);
-  const dropEnumQuery = await execStdOut('psql', [ databaseUrl, '--tuples-only', '--command', 'select string_agg(\'drop type "\' || typname || \'"\', \'; \') from (select distinct t.typname from pg_type t join pg_enum e on t.oid = e.enumtypid join pg_namespace as n on t.typnamespace = n.oid where n.nspname = \'public\') as typenames;' ]);
-  const dropFunction = await execStdOut('psql', [ databaseUrl, '--tuples-only', '--command', 'select string_agg(\'drop function "\' || proname || \'"\', \'; \') FROM pg_proc pp INNER JOIN pg_roles pr ON pp.proowner = pr.oid WHERE pr.rolname = current_user ' ]);
-  const dropViews = await execStdOut('psql', [ databaseUrl, '--tuples-only', '--command', 'select string_agg(\'drop view "\' || viewname || \'"\', \'; \') FROM pg_views where viewowner=current_user']);
   await exec('psql', [ databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropTableQuery ]);
+  const dropEnumQuery = await execStdOut('psql', [ databaseUrl, '--tuples-only', '--command', 'select string_agg(\'drop type "\' || typname || \'"\', \'; \') from (select distinct t.typname from pg_type t join pg_enum e on t.oid = e.enumtypid join pg_namespace as n on t.typnamespace = n.oid where n.nspname = \'public\') as typenames;' ]);
   await exec('psql', [ databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropEnumQuery ]);
+  const dropViews = await execStdOut('psql', [ databaseUrl, '--tuples-only', '--command', 'select string_agg(\'drop view "\' || viewname || \'"\', \'; \') FROM pg_views where viewowner=current_user']);
   await exec('psql', [ databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropViews ]);
+  const dropFunction = await execStdOut('psql', [ databaseUrl, '--tuples-only', '--command', 'select string_agg(\'drop function "\' || proname || \'"\', \'; \') FROM pg_proc pp INNER JOIN pg_roles pr ON pp.proowner = pr.oid WHERE pr.rolname = current_user ' ]);
   return exec('psql', [ databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropFunction ]);
 }
 

--- a/test/integration/steps/backup-restore/enrichment_test.js
+++ b/test/integration/steps/backup-restore/enrichment_test.js
@@ -107,7 +107,7 @@ describe('Integration | Steps | Backup restore | enrichment.js', function() {
 
         // then
         const passwordsString = await database.runSql('SELECT "authenticationComplement" -> \'password\' FROM "authentication-methods"');
-        expect(passwordsString.match(/\$.*\$.*\$x+/g)).to.be.null;
+        expect(passwordsString.length).to.greaterThan(19);
       });
     });
 
@@ -153,7 +153,7 @@ describe('Integration | Steps | Backup restore | enrichment.js', function() {
 
         // then
         const passwordsString = await database.runSql('SELECT "authenticationComplement" -> \'password\' FROM "authentication-methods"');
-        expect(passwordsString.match(/\$.*\$.*\$x+/g).length).to.equal(2);
+        expect(passwordsString.length).to.equal(19);
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, la réplication prend beaucoup deux temps, principalement à cause de deux problèmes:
- Une erreur survient lors du drop d'une vue faisant perdre 1h de traitement.
- La requête de mise à jour des mots de passe prend trop de temps.

## :robot: Solution
- Ne pas exécuter la commande de récupération des vues avant le drop des tables.
- Ne pas rajouter les caractères de padding aux mots de passe.