### PR TITLE
[TECH] Mise à jour de bull-repl.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Connectez-vous à `bull`
 
 ```bash
 scalingo --region osc-secnum-fr1 --app pix-datawarehouse-production run bull-repl
-connect "Replication queue"
+connect --uri #valeur de REDIS_URL# "Replication queue"
 #connect "Incremental replication queue"
 #connect "Learning Content replication queue"
 failed

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@sentry/node": "^8.0.0",
         "axios": "^1.3.4",
         "bull": "^4.10.0",
-        "bull-repl": "^0.29.0",
+        "bull-repl": "^1.10.2",
         "bunyan": "^1.8.14",
         "check-engine": "^1.10.0",
         "dotenv": "^16.0.0",
@@ -1883,20 +1883,54 @@
       }
     },
     "node_modules/bull-repl": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmjs.org/bull-repl/-/bull-repl-0.29.1.tgz",
-      "integrity": "sha512-vu6p2KkY3KAIF4xmG/PdMzFPyWNVHDGHRiZ1J/TG4oVFpi13m384YhG2FLP9umLzs0TI9Evil2CZrubcfnAsVg==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/bull-repl/-/bull-repl-1.10.2.tgz",
+      "integrity": "sha512-UsA5hCMH5Oz+eodIAhdHKp/OOF6mBriVvgqWBN2J7dEey7Kmn4APlg9n97sbzOFzv6hMfeTAGmEWfBG8/OStbA==",
       "license": "MIT",
       "dependencies": {
         "@moleculer/vorpal": "^1.11.5",
-        "bull": "^4.12.2",
-        "chalk": "^4.1.0",
+        "bullmq": "^5.3.0",
+        "chalk": "^4.1.2",
+        "ioredis": "^5.3.2",
         "ms": "^2.1.3",
-        "node-jq": "^4.3.0",
-        "redis-url-plus": "^1.1.0"
+        "node-jq": "^4.3.0"
       },
       "bin": {
         "bull-repl": "index.js"
+      }
+    },
+    "node_modules/bullmq": {
+      "version": "5.34.10",
+      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.34.10.tgz",
+      "integrity": "sha512-ia6EzpQm1ZPq6GUBSLyfvzJrhdBTd1f3Gn2g9pFtLX4hBOob6QHmcmBzGgPlSCyr/i2Qfe4OdjS21bRd02srbw==",
+      "license": "MIT",
+      "dependencies": {
+        "cron-parser": "^4.9.0",
+        "ioredis": "^5.4.1",
+        "msgpackr": "^1.11.2",
+        "node-abort-controller": "^3.1.1",
+        "semver": "^7.5.4",
+        "tslib": "^2.0.0",
+        "uuid": "^9.0.0"
+      }
+    },
+    "node_modules/bullmq/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/bullmq/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/bunyan": {
@@ -5037,6 +5071,12 @@
         "node": ">= 10.13"
       }
     },
+    "node_modules/node-abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
+      "license": "MIT"
+    },
     "node_modules/node-downloader-helper": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/node-downloader-helper/-/node-downloader-helper-2.1.9.tgz",
@@ -5778,12 +5818,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/redis-url-plus": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/redis-url-plus/-/redis-url-plus-1.2.1.tgz",
-      "integrity": "sha512-Mil6/AnHW4PhgKbDSiqyolVtoYFJeuqnCSLFLkuxrirSpdlyTUbw/USkFVA/vuVS83A7FB0R6Z81N71q5/u77g==",
-      "license": "MIT"
     },
     "node_modules/reduce-flatten": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@sentry/node": "^8.0.0",
     "axios": "^1.3.4",
     "bull": "^4.10.0",
-    "bull-repl": "^0.29.0",
+    "bull-repl": "^1.10.2",
     "bunyan": "^1.8.14",
     "check-engine": "^1.10.0",
     "dotenv": "^16.0.0",


### PR DESCRIPTION
## :unicorn: Problème

La version 4.x de bull n'est pas supportée par bull-repl.

## :robot: Solution
On passe à la version bull-repl@next.

## :rainbow: Remarques

RAS

## :100: Pour tester


Sur la review app, exécuter `scalingo -a pix-db-replication-prxxx run bull-repl`
Dans le repl, se connecter à queue avec `connect "Learning Content replication queue"`
Lancer la commande `stats`
Constater que les statisques des jobs sont affichées.
