### PR TITLE
[Fix] thematics table schema and add learning content replication logs

### DIFF
--- a/src/database-helper.js
+++ b/src/database-helper.js
@@ -5,6 +5,7 @@ import _ from 'lodash';
 
 import { PrimaryKeyNotNullConstraintError } from './errors.js';
 import * as learningContentHelper from './steps/learning-content/learning-content-helper.js';
+import { logger } from './logger.js';
 
 const LCMS_CHUNK = 2000;
 
@@ -23,12 +24,14 @@ async function runDBOperation(callback, configuration) {
 async function dropTable(tableName, configuration) {
   return runDBOperation(async (client) => {
     const dropQuery = `DROP TABLE IF EXISTS ${format.ident(tableName)} CASCADE`;
+    logger.info(`${dropQuery}`);
     await client.query(dropQuery);
   }, configuration);
 }
 
 async function createTable(tableStructure, configuration) {
   await runDBOperation(async (client) => {
+    logger.info(`CREATE TABLE ${tableStructure.name}`);
     const fieldsText = ['"id" text PRIMARY KEY'].concat(tableStructure.fields.map((field) => {
       return format('\t%I\t%s', field.name, field.type + (field.type === 'boolean' ? ' NOT NULL' : ''));
     })).join(',\n');
@@ -44,6 +47,7 @@ async function createTable(tableStructure, configuration) {
 async function saveLearningContent(table, learningContent, configuration) {
   if (learningContent.length) {
     await runDBOperation(async (client) => {
+      logger.info(`Saving learning content in table ${table.name}`);
       const fieldNames = ['id'].concat(table.fields.map((field) => field.name));
       for await (const learningContentChunk of _.chunk(learningContent, LCMS_CHUNK)) {
         const values = _computeValuesToInsert(table, learningContentChunk);

--- a/src/errors.js
+++ b/src/errors.js
@@ -5,6 +5,14 @@ class PrimaryKeyNotNullConstraintError extends Error {
   }
 }
 
+class NoLearningContentError extends Error {
+  constructor() {
+    const message = 'No learning content retrieved';
+    super(message);
+  }
+}
+
 export {
   PrimaryKeyNotNullConstraintError,
+  NoLearningContentError,
 };

--- a/src/steps/learning-content/index.js
+++ b/src/steps/learning-content/index.js
@@ -1,5 +1,6 @@
 import * as lcmsClient from './lcms-client.js';
 import * as databaseHelper from '../../database-helper.js';
+import { NoLearningContentError } from './../../errors.js';
 import { logger } from './../../logger.js';
 
 const tables = [{
@@ -161,6 +162,9 @@ async function run(configuration, dependencies = { databaseHelper: databaseHelpe
       await dependencies.databaseHelper.createTable(table, configuration);
       await dependencies.databaseHelper.saveLearningContent(table, learningContent[table.name], configuration);
     }
+  }
+  else {
+    throw new NoLearningContentError();
   }
 }
 

--- a/src/steps/learning-content/index.js
+++ b/src/steps/learning-content/index.js
@@ -36,12 +36,12 @@ const tables = [{
 }, {
   name: 'thematics',
   fields: [
-    { name: 'name', type: 'text' },
-    { name: 'index', type: 'smallint' },
+    { name: 'name', type: 'text', extractor: (record) => record['name_i18n']['fr'] },
+    { name: 'index', type: 'text', extractor: (record) => record['id'] },
     { name: 'competenceId', type: 'text', isArray: false },
     { name: 'tubeIds', type: 'text', isArray: true },
   ],
-  indexes: [],
+  indexes: ['index'],
 }, {
   name: 'tubes',
   fields: [

--- a/src/steps/learning-content/index.js
+++ b/src/steps/learning-content/index.js
@@ -1,5 +1,6 @@
 import * as lcmsClient from './lcms-client.js';
 import * as databaseHelper from '../../database-helper.js';
+import { logger } from './../../logger.js';
 
 const tables = [{
   name: 'frameworks',
@@ -152,6 +153,7 @@ const tables = [{
 }];
 
 async function run(configuration, dependencies = { databaseHelper: databaseHelper, lcmsClient: lcmsClient }) {
+  logger.info(`Learning content replication : tables ${tables.map((table) => table.name).join([', '])}`);
   const learningContent = await dependencies.lcmsClient.getLearningContent(configuration);
   if (learningContent) {
     for await (const table of tables) {


### PR DESCRIPTION
## :unicorn: Problème
La réplication du learning content est difficile à deboguer. De plus, de shéma de la table thématics ne correspond pas au schéma de la table répliquée.

## :robot: Solution
Correction sur la table thematics et ajout de logs

## :rainbow: Remarques

## :100: Pour tester
NOM_APPLICATION=pix-datawarehouse-integration-pr283
scalingo run --region osc-fr1 --app $NOM_APPLICATION npm run restart:learning-content-replication
scalingo --region osc-fr1 --app $NOM_APPLICATION logs
