### PR TITLE
[FEATURE] Ajout des informations manquantes pour la table tutorials, source - format - duration

### DIFF
--- a/src/steps/learning-content/index.js
+++ b/src/steps/learning-content/index.js
@@ -132,7 +132,7 @@ const tables = [{
     { name: 'format', type: 'text' },
     { name: 'link', type: 'text' },
     { name: 'source', type: 'text' },
-    { name: 'title', type: 'text' },        
+    { name: 'title', type: 'text' },
     { name: 'tutorialForSkills', type: 'text []', isArray: true },
     { name: 'furtherInformation', type: 'text []', isArray: true },
     { name: 'locale', type: 'text' },

--- a/src/steps/learning-content/index.js
+++ b/src/steps/learning-content/index.js
@@ -132,8 +132,6 @@ const tables = [{
     { name: 'format', type: 'text' },
     { name: 'link', type: 'text' },
     { name: 'source', type: 'text' },
-    { name: 'tutorialForSkills', type: 'text []', isArray: true },
-    { name: 'furtherInformation', type: 'text []', isArray: true },
     { name: 'locale', type: 'text' },
   ],
   indexes: ['title'],

--- a/src/steps/learning-content/index.js
+++ b/src/steps/learning-content/index.js
@@ -128,7 +128,11 @@ const tables = [{
   name: 'tutorials',
   fields: [
     { name: 'title', type: 'text' },
+    { name: 'duration', type: 'text' },
+    { name: 'format', type: 'text' },
     { name: 'link', type: 'text' },
+    { name: 'source', type: 'text' },
+    { name: 'title', type: 'text' },        
     { name: 'tutorialForSkills', type: 'text []', isArray: true },
     { name: 'furtherInformation', type: 'text []', isArray: true },
     { name: 'locale', type: 'text' },

--- a/src/steps/learning-content/index.js
+++ b/src/steps/learning-content/index.js
@@ -132,7 +132,6 @@ const tables = [{
     { name: 'format', type: 'text' },
     { name: 'link', type: 'text' },
     { name: 'source', type: 'text' },
-    { name: 'title', type: 'text' },
     { name: 'tutorialForSkills', type: 'text []', isArray: true },
     { name: 'furtherInformation', type: 'text []', isArray: true },
     { name: 'locale', type: 'text' },


### PR DESCRIPTION
## :unicorn: Problème
Afin d'éviter au contenu d'accéder à airtable directement, ajout des infos de tutos dans metabase.
Cf. https://1024pix.slack.com/archives/C9ZJZT1S4/p1738075829088939

## :robot: Solution
ajout de colonnes à la répli

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
