### PR TITLE
[FEATURE] Empêcher la suppression de table à partir d'un pattern (PIX-17035)

### DIFF
--- a/src/steps/backup-restore/index.js
+++ b/src/steps/backup-restore/index.js
@@ -20,8 +20,8 @@ async function dropCurrentObjects(configuration) {
 }
 
 async function dropCurrentObjectsExceptTables(databaseUrl, tableNames) {
-  const tableNamesForQuery = tableNames.map((tableName) => `'${tableName}'`).join(',');
-  const dropTableQuery = await execStdOut('psql', [databaseUrl, '--tuples-only', '--command', `select string_agg('drop table "' || tablename || '" CASCADE', '; ') from pg_tables where schemaname = 'public' and tablename not in (${tableNamesForQuery});`]);
+  const tableNamesForQuery = tableNames.map((tableName) => tableName.includes('*') ? `(${tableName.replace('*', '.*')})` : `(${tableName})`).join('|');
+  const dropTableQuery = await execStdOut('psql', [databaseUrl, '--tuples-only', '--command', `select string_agg('drop table "' || tablename || '" CASCADE', '; ') from pg_tables where schemaname = 'public' and tablename !~ '${tableNamesForQuery}';`]);
   await exec('psql', [databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropTableQuery]);
   const dropEnumQuery = await execStdOut('psql', [databaseUrl, '--tuples-only', '--command', 'select string_agg(\'drop type "\' || typname || \'"\', \'; \') from (select distinct t.typname from pg_type t join pg_enum e on t.oid = e.enumtypid join pg_namespace as n on t.typnamespace = n.oid where n.nspname = \'public\') as typenames;']);
   await exec('psql', [databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropEnumQuery]);

--- a/test/integration/steps/backup-restore/index_test.js
+++ b/test/integration/steps/backup-restore/index_test.js
@@ -544,6 +544,37 @@ describe('Integration | Steps | Backup restore | index.js', function() {
       });
     });
 
+    context('When tables are excluded from a pattern', function() {
+      it('should not drop the tables', async function() {
+        // given
+        await targetDatabase.runSql('CREATE TABLE "data_test_1" (id int NOT NULL PRIMARY KEY, metric int not null)');
+        await targetDatabase.runSql('INSERT INTO "data_test_1" (id, metric) VALUES (1, 123)');
+        await targetDatabase.runSql('CREATE TABLE "data_test_2" (id int NOT NULL PRIMARY KEY, metric int not null)');
+        await targetDatabase.runSql('INSERT INTO "data_test_2" (id, metric) VALUES (1, 456)');
+
+        // when
+        const backupFile = await createBackup(sourceDatabase, sourceDatabaseConfig, { createTablesNotToBeImported: true });
+        const configuration = {
+          BACKUP_MODE: {
+            'knowledge-elements': 'incremental',
+            'knowledge-element-snapshots': 'incremental',
+            'answers': 'incremental',
+            'data_*': 'none',
+          },
+          DATABASE_URL: targetDatabase._databaseUrl,
+          PG_RESTORE_JOBS: 4,
+        };
+        await steps.dropObjectAndRestoreBackup(backupFile, configuration);
+
+        // then
+        const dataTest1Count = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM "data_test_1"'));
+        expect(dataTest1Count).to.equal(1);
+
+        const dataTest2Count = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM "data_test_2"'));
+        expect(dataTest2Count).to.equal(1);
+      });
+    });
+
     it('should not fail when database contains plpgsql source (pg functions)', async function() {
       // given
 


### PR DESCRIPTION
## :unicorn: Problème

Toutes les tables (dont les `data_*`) de la base de donnée cible sont supprimées sauf celles renseignées dans la variable d’environnement `BACKUP_MODE`. Il y a beaucoup de tables débutant par `data_`.

Nous souhaitons que les tables `data_` restent afin d'exposer de la donnée à tout moment.

## :robot: Solution
Permettre de mettre `*` pour spécifier un pattern de nom de tables qui ne sera pas supprimées.

## :rainbow: Remarques


## :100: Pour tester
Lancer les tests.
