### PR TITLE
[BUGFIX] Supprimer les tables element-answers et activity-answers

### DIFF
--- a/src/steps/backup-restore/index.js
+++ b/src/steps/backup-restore/index.js
@@ -21,7 +21,7 @@ async function dropCurrentObjects(configuration) {
 
 async function dropCurrentObjectsExceptTables(databaseUrl, tableNames) {
   const tableNamesForQuery = tableNames.map((tableName) => tableName.includes('*') ? `(${tableName.replace('*', '.*')})` : `(${tableName})`).join('|');
-  const dropTableQuery = await execStdOut('psql', [databaseUrl, '--tuples-only', '--command', `select string_agg('drop table "' || tablename || '" CASCADE', '; ') from pg_tables where schemaname = 'public' and tablename !~ '${tableNamesForQuery}';`]);
+  const dropTableQuery = await execStdOut('psql', [databaseUrl, '--tuples-only', '--command', `select string_agg('drop table "' || tablename || '" CASCADE', '; ') from pg_tables where schemaname = 'public' and tablename !~ '^(${tableNamesForQuery})$';`]);
   await exec('psql', [databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropTableQuery]);
   const dropEnumQuery = await execStdOut('psql', [databaseUrl, '--tuples-only', '--command', 'select string_agg(\'drop type "\' || typname || \'"\', \'; \') from (select distinct t.typname from pg_type t join pg_enum e on t.oid = e.enumtypid join pg_namespace as n on t.typnamespace = n.oid where n.nspname = \'public\') as typenames;']);
   await exec('psql', [databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropEnumQuery]);

--- a/test/integration/steps/backup-restore/index_test.js
+++ b/test/integration/steps/backup-restore/index_test.js
@@ -551,6 +551,10 @@ describe('Integration | Steps | Backup restore | index.js', function() {
         await targetDatabase.runSql('INSERT INTO "data_test_1" (id, metric) VALUES (1, 123)');
         await targetDatabase.runSql('CREATE TABLE "data_test_2" (id int NOT NULL PRIMARY KEY, metric int not null)');
         await targetDatabase.runSql('INSERT INTO "data_test_2" (id, metric) VALUES (1, 456)');
+        await targetDatabase.runSql('CREATE TABLE "table_with_data_inside" (id int NOT NULL PRIMARY KEY, metric int not null)');
+        await targetDatabase.runSql('INSERT INTO "table_with_data_inside" (id, metric) VALUES (1, 456)');
+        await targetDatabase.runSql('CREATE TABLE "table_with_answers_inside" (id int NOT NULL PRIMARY KEY)');
+        await targetDatabase.runSql('INSERT INTO "table_with_answers_inside" (id) VALUES (1)');
 
         // when
         const backupFile = await createBackup(sourceDatabase, sourceDatabaseConfig, { createTablesNotToBeImported: true });
@@ -572,6 +576,12 @@ describe('Integration | Steps | Backup restore | index.js', function() {
 
         const dataTest2Count = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM "data_test_2"'));
         expect(dataTest2Count).to.equal(1);
+
+        const tableWithDataInsideCount = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'table_with_data_inside\''));
+        expect(tableWithDataInsideCount).to.equal(0);
+
+        const tableWithAnswersInsideCount = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM information_schema.tables t WHERE t.table_name = \'table_with_answers_inside\''));
+        expect(tableWithAnswersInsideCount).to.equal(0);
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème


Les tables `element-answers` et `activity-answers` n'ont pas été supprimé, car elles contiennent `answers` dans le nom, `answers` qui est configuré dans la variable `BACKUP_MODE`.

## :robot: Solution

Rendre plus strict la regex filtrant les tables à supprimer en ajoutant `^` et `$` signifiant début et fin.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
La ci.
