### PR TITLE
[TECH] Utiliser l'autre endpoint auprès de LCMS pour récupérer les données de réplication

### DIFF
--- a/src/steps/learning-content/lcms-client.js
+++ b/src/steps/learning-content/lcms-client.js
@@ -4,7 +4,7 @@ import { logger } from '../../logger.js';
 const timeout = 60 * 1000 * 3;
 
 async function getLearningContent(configuration) {
-  const url = configuration.LCMS_API_URL + '/databases/airtable';
+  const url = configuration.LCMS_API_URL + '/replication-data';
   // eslint-disable-next-line n/no-process-env
   const application = process.env.APP || 'pix-db-replication';
   const headers = {

--- a/test/integration/steps/learning-content/lcms-client_test.js
+++ b/test/integration/steps/learning-content/lcms-client_test.js
@@ -27,7 +27,7 @@ describe('Integration | Steps | learning-content | lcms-client.js', function() {
           authorization: 'Bearer abcd',
           client: 'pix-db-replication',
         } })
-        .get('/api/databases/airtable')
+        .get('/api/replication-data')
         .reply(200, '{}');
 
       // when
@@ -44,7 +44,7 @@ describe('Integration | Steps | learning-content | lcms-client.js', function() {
           authorization: 'Bearer abcd',
           client: 'pix-db-replication',
         } })
-        .get('/api/databases/airtable')
+        .get('/api/replication-data')
         .delay(100)
         .reply(200, '{}');
 

--- a/test/unit/steps/learning-content/lcms-client_test.js
+++ b/test/unit/steps/learning-content/lcms-client_test.js
@@ -9,7 +9,7 @@ describe('Unit | Steps | learning content | lcms-client.js', function() {
     beforeEach(function() {
       const lcmsApiUrl = 'https://lcms-test.pix.fr/api';
       const lcmsApiKey = 'abcd';
-      learningContentGetUrl = lcmsApiUrl + '/databases/airtable';
+      learningContentGetUrl = lcmsApiUrl + '/replication-data';
       headers = {
         'Authorization': `Bearer ${lcmsApiKey}`,
         client: 'pix-db-replication',


### PR DESCRIPTION
## :unicorn: Problème
Côté LCMS on a deux routes qui font la même chose mais qui s'appelle pas pareil
GET api/databases/airtable
GET api/replication-data

On veut garder que replication-data

## :robot: Solution
Remplacer les appels à api/databases/airtable par api/replication-data

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
