### PR TITLE
[TECH] Remettre à nouveau les translations dans la réplication récupérées depuis LCMS

### DIFF
--- a/src/steps/learning-content/index.js
+++ b/src/steps/learning-content/index.js
@@ -153,7 +153,20 @@ const tables = [{
     { name: 'content', type: 'jsonb', extractor: (record) => JSON.stringify(record.content) },
   ],
   indexes: [],
-}];
+},
+{
+  name: 'translations',
+  fields: [
+    { name: 'key', type: 'text', extractor: extractTranslationsKey },
+    { name: 'locale', type: 'text' },
+    { name: 'value', type: 'text' },
+    { name: 'model', type: 'text' },
+    { name: 'entityId', type: 'text' },
+    { name: 'sourceEntityId', type: 'text' },
+  ],
+  indexes: [],
+},
+];
 
 async function run(configuration, dependencies = { databaseHelper: databaseHelper, lcmsClient: lcmsClient }) {
   logger.info(`Learning content replication : tables ${tables.map((table) => table.name).join([', '])}`);
@@ -170,6 +183,16 @@ async function run(configuration, dependencies = { databaseHelper: databaseHelpe
   }
 }
 
+function extractTranslationsKey(record) {
+  const [model, id, field] = record.key.split('.');
+
+  if (model !== 'challenge' || field !== 'solutionToDisplay') {
+    return record.key;
+  }
+  return `${model}.${id}.explicativeResponse`;
+}
+
 export {
   run,
+  extractTranslationsKey,
 };

--- a/src/steps/learning-content/index.js
+++ b/src/steps/learning-content/index.js
@@ -155,7 +155,8 @@ const tables = [{
   indexes: [],
 },
 {
-  name: 'translations',
+  name: 'learning-content-translations',
+  sourceName: 'translations',
   fields: [
     { name: 'key', type: 'text', extractor: extractTranslationsKey },
     { name: 'locale', type: 'text' },
@@ -175,7 +176,8 @@ async function run(configuration, dependencies = { databaseHelper: databaseHelpe
     for await (const table of tables) {
       await dependencies.databaseHelper.dropTable(table.name, configuration);
       await dependencies.databaseHelper.createTable(table, configuration);
-      await dependencies.databaseHelper.saveLearningContent(table, learningContent[table.name], configuration);
+      const keyInLCMSPayload = table.sourceName ?? table.name;
+      await dependencies.databaseHelper.saveLearningContent(table, learningContent[keyInLCMSPayload], configuration);
     }
   }
   else {

--- a/test/acceptance/full-dump-replication-test.js
+++ b/test/acceptance/full-dump-replication-test.js
@@ -11,7 +11,7 @@ import { run as runLearningContent } from '../../src/steps/learning-content/inde
 import * as databaseHelper from '../../src/database-helper.js';
 
 async function getCountFromTable({ targetDatabase, tableName }) {
-  return parseInt(await targetDatabase.runSql(`SELECT COUNT(*) FROM ${tableName}`));
+  return parseInt(await targetDatabase.runSql(`SELECT COUNT(*) FROM "${tableName}"`));
 }
 
 // CircleCI set up environment variables to access DB, so we need to read them here
@@ -173,7 +173,7 @@ describe('Acceptance | fullReplicationAndEnrichment', function() {
 
     it('should import translations ', async function() {
       // then
-      const result = await getCountFromTable({ targetDatabase, tableName: 'translations' });
+      const result = await getCountFromTable({ targetDatabase, tableName: 'learning-content-translations' });
       expect(result).to.equal(fullLearningContent.translations.length);
     });
   });

--- a/test/acceptance/full-dump-replication-test.js
+++ b/test/acceptance/full-dump-replication-test.js
@@ -170,6 +170,12 @@ describe('Acceptance | fullReplicationAndEnrichment', function() {
       const result = await getCountFromTable({ targetDatabase, tableName: 'missions' });
       expect(result).to.equal(fullLearningContent.missions.length);
     });
+
+    it('should import translations ', async function() {
+      // then
+      const result = await getCountFromTable({ targetDatabase, tableName: 'translations' });
+      expect(result).to.equal(fullLearningContent.translations.length);
+    });
   });
 
   describe('should enrich imported data', function() {

--- a/test/unit/steps/learning-content/index_test.js
+++ b/test/unit/steps/learning-content/index_test.js
@@ -37,7 +37,7 @@ describe('Unit | Steps | learning-content | index.js', function() {
     });
 
     it('should drop existing learning-content tables', async function() {
-      expect(databaseHelper.dropTable.callCount).to.equal(11);
+      expect(databaseHelper.dropTable.callCount).to.equal(12);
       expect(databaseHelper.dropTable).to.have.been.calledWith('frameworks');
       expect(databaseHelper.dropTable).to.have.been.calledWith('areas');
       expect(databaseHelper.dropTable).to.have.been.calledWith('attachments');
@@ -49,14 +49,28 @@ describe('Unit | Steps | learning-content | index.js', function() {
       expect(databaseHelper.dropTable).to.have.been.calledWith('courses');
       expect(databaseHelper.dropTable).to.have.been.calledWith('tutorials');
       expect(databaseHelper.dropTable).to.have.been.calledWith('missions');
+      expect(databaseHelper.dropTable).to.have.been.calledWith('translations');
     });
 
     it('should create learning-content tables', async function() {
-      expect(databaseHelper.createTable.callCount).to.equal(11);
+      expect(databaseHelper.createTable.callCount).to.equal(12);
     });
 
     it('should insert learning-content data', async function() {
-      expect(databaseHelper.saveLearningContent.callCount).to.equal(11);
+      expect(databaseHelper.saveLearningContent.callCount).to.equal(12);
+    });
+  });
+
+  describe('#extractTranslationsKey', function() {
+    it('should extract solutionToDisplay translation key into explicativeResponse', function() {
+      // given
+      const record = { key: 'challenge.id.solutionToDisplay', locale: 'fr', value: 'la solution à afficher', model: 'challenge', entityId: 'id', sourceEntityId: 'id' };
+
+      // when
+      const result = learningContent.extractTranslationsKey(record);
+
+      // then
+      expect(result).to.equal('challenge.id.explicativeResponse');
     });
   });
 });

--- a/test/unit/steps/learning-content/index_test.js
+++ b/test/unit/steps/learning-content/index_test.js
@@ -49,7 +49,7 @@ describe('Unit | Steps | learning-content | index.js', function() {
       expect(databaseHelper.dropTable).to.have.been.calledWith('courses');
       expect(databaseHelper.dropTable).to.have.been.calledWith('tutorials');
       expect(databaseHelper.dropTable).to.have.been.calledWith('missions');
-      expect(databaseHelper.dropTable).to.have.been.calledWith('translations');
+      expect(databaseHelper.dropTable).to.have.been.calledWith('learning-content-translations');
     });
 
     it('should create learning-content tables', async function() {

--- a/test/utils/mock-lcms-get-airtable.js
+++ b/test/utils/mock-lcms-get-airtable.js
@@ -945,6 +945,17 @@ function mockLcmsAirtableData() {
         content: { dareChallenges: [], steps: [] },
       },
     ],
+    'translations': [
+      {
+        id: 'challenge.id.solutionToDisplay',
+        key: 'challenge.id.solutionToDisplay',
+        locale: 'fr',
+        value: 'la solution à afficher',
+        model: 'challenge',
+        entityId: 'id',
+        sourceEntityId: 'id',
+      },
+    ],
   };
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Divers problèmes techniques côté LCMS ont fait qu'on a dû revert plusieurs fois le fait d'exposer les traductions dans la répli.
Suite à cette PR https://github.com/1024pix/pix-editor/pull/959
on pense que c'est résolu et qu'on peut retenter notre chance

## :robot: Solution
RE-revert des commits permettant d'exposer les données de trads

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
