### PR TITLE
[FEATURE] Permettre de passer un body à l'appel d'une notification

### DIFF
--- a/src/steps/notification.js
+++ b/src/steps/notification.js
@@ -20,7 +20,7 @@ async function notifyUrl(notification) {
     const headers = !isAuthenticated ? {} : {
       Authorization: notification.token,
     };
-    const response = await axios.post(notification.url, {}, {
+    const response = await axios.post(notification.url, notification.body, {
       headers,
     });
     return response;

--- a/test/integration/steps/notification_test.js
+++ b/test/integration/steps/notification_test.js
@@ -8,6 +8,7 @@ describe('Integration | Steps | notification.js', function() {
         NOTIFICATIONS: [
           { url: 'http://example.net/webhook1' },
           { url: 'http://example.net/webhook2', token: 'mon-super-token' },
+          { url: 'http://example.net/webhook3', token: 'mon-super-token', body: { 'key': 'value' } },
         ],
       };
 
@@ -20,10 +21,16 @@ describe('Integration | Steps | notification.js', function() {
         .matchHeader('Authorization', 'mon-super-token')
         .reply(200, {});
 
+      const scopeWebhook3 = nock('http://example.net')
+        .post('/webhook3', { key: 'value' })
+        .matchHeader('Authorization', 'mon-super-token')
+        .reply(200, {});
+
       await run(configuration);
 
       expect(scopeWebhook1.isDone()).to.be.true;
       expect(scopeWebhook2.isDone()).to.be.true;
+      expect(scopeWebhook3.isDone()).to.be.true;
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Afin de chaîner la fin de la réplication aux traitements data nous souhaitons utiliser le sytème de notification proposé par la pix-db-replication. L'API Airflow propose un endpoint `/datasets/events` permettant de créer un évènement sur un Dataset paramétré dans le body `{ "dataset_uri": "string" }`.

## :robot: Solution

Permettre d'ajouter un body à la notification en gérant la clé `body` dans la variable d'env `NOTIFICATIONS`.

## :rainbow: Remarques

Nous utilisons un Dataset côté Airflow afin de ne pas déplacer la connaissance de ce qui est exécuté après la réplication côté répli, mais simplement la connaissance d'avoir mis à jour un Dataset appelé "Réplication" (cf https://github.com/1024pix/pix-data/pull/825).

## :100: Pour tester
CI.
