### PR TITLE
[FEATURE] Ajout de `embedTitle` sur `challenges` (PIX-17743)

### DIFF
--- a/src/steps/learning-content/index.js
+++ b/src/steps/learning-content/index.js
@@ -86,6 +86,7 @@ const tables = [{
     { name: 'thirdSkillId', type: 'text', extractor: (_) => undefined },
     { name: 'languages', type: 'text []', isArray: true, extractor: (record) => record['locales'] },
     { name: 'embedUrl', type: 'text' },
+    { name: 'embedTitle', type: 'text' },
     { name: 'hasEmbedUrl', type: 'boolean', extractor: (record) => !!record['embedUrl'] },
     { name: 'alternativeInstruction', type: 'text' },
     { name: 'hasAlternativeInstruction', type: 'boolean', extractor: (record) => !!record['alternativeInstruction'] },


### PR DESCRIPTION
## :unicorn: Problème
On souhaite avoir le titre d’embed sur les challenges.

## :robot: Solution
Recopier le champ qui est déjà dispo sur le endpoint LCMS.

## :rainbow: Remarques
N/A

## :100: Pour tester
Répli lancée sur la RA :
```
pix_datawar_9466=> \d
                         List of relations
 Schema |             Name              | Type  |      Owner       
--------+-------------------------------+-------+------------------
 public | areas                         | table | pix_datawar_9466
 public | attachments                   | table | pix_datawar_9466
 public | challenges                    | table | pix_datawar_9466
 public | competences                   | table | pix_datawar_9466
 public | courses                       | table | pix_datawar_9466
 public | frameworks                    | table | pix_datawar_9466
 public | learning-content-translations | table | pix_datawar_9466
 public | missions                      | table | pix_datawar_9466
 public | skills                        | table | pix_datawar_9466
 public | thematics                     | table | pix_datawar_9466
 public | tubes                         | table | pix_datawar_9466
 public | tutorials                     | table | pix_datawar_9466
(12 rows)

pix_datawar_9466=> \d challenges
                               Table "public.challenges"
          Column           |           Type           | Collation | Nullable | Default 
---------------------------+--------------------------+-----------+----------+---------
 id                        | text                     |           | not null | 
 instruction               | text                     |           |          | 
 status                    | text                     |           |          | 
 type                      | text                     |           |          | 
 timer                     | smallint                 |           |          | 
 autoReply                 | boolean                  |           | not null | 
 skillId                   | text                     |           |          | 
 skillIds                  | text[]                   |           |          | 
 skillCount                | smallint                 |           |          | 
 firstSkillId              | text                     |           |          | 
 secondSkillId             | text                     |           |          | 
 thirdSkillId              | text                     |           |          | 
 languages                 | text[]                   |           |          | 
 embedUrl                  | text                     |           |          | 
 embedTitle                | text                     |           |          | 
 hasEmbedUrl               | boolean                  |           | not null | 
 alternativeInstruction    | text                     |           |          | 
 hasAlternativeInstruction | boolean                  |           | not null | 
 area                      | text                     |           |          | 
 focus                     | boolean                  |           | not null | 
 explicativeResponse       | text                     |           |          | 
 delta                     | numeric                  |           |          | 
 alpha                     | numeric                  |           |          | 
 createdAt                 | timestamp with time zone |           |          | 
 validatedAt               | timestamp with time zone |           |          | 
 archivedAt                | timestamp with time zone |           |          | 
 madeObsoleteAt            | timestamp with time zone |           |          | 
 accessibility1            | text                     |           |          | 
 accessibility2            | text                     |           |          | 
 spoil                     | text                     |           |          | 
 responsive                | text                     |           |          | 
 deafAndHardOfHearing      | text                     |           |          | 
 requireGafamWebsiteAccess | boolean                  |           | not null | 
 isIncompatibleIpadCertif  | boolean                  |           | not null | 
 toRephrase                | boolean                  |           | not null | 
 isAwarenessChallenge      | boolean                  |           | not null | 
 genealogy                 | text                     |           |          | 
 version                   | smallint                 |           |          | 
 alternativeVersion        | smallint                 |           |          | 
 declinable                | text                     |           |          | 
 proposals                 | text                     |           |          | 
 solution                  | text                     |           |          | 
 pedagogy                  | text                     |           |          | 
 shuffled                  | boolean                  |           | not null | 
 contextualizedFields      | text[]                   |           |          | 
 urlsToConsult             | text[]                   |           |          | 
Indexes:
    "challenges_pkey" PRIMARY KEY, btree (id)
    "challenges_firstSkillId_idx" btree ("firstSkillId")
```