### PR TITLE
[FEATURE] Inclure les métadonnées de modules dans pix-datawarehouse-production (PIX-17912)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ import { pgclientSetup } from './setup.js';
 import * as steps from './steps/index.js';
 import { configuration, jobOptions, repeatableJobOptions } from './config/index.js';
 
+const modulixLearningContentReplicationQueue = _createQueue('Modulix Learning Content replication queue');
 const replicationQueue = _createQueue('Replication queue');
 const learningContentReplicationQueue = _createQueue('Learning Content replication queue');
 const incrementalReplicationQueue = _createQueue('Incremental replication queue');
@@ -22,6 +23,15 @@ main()
 async function main() {
   await initSentry(configuration);
   await pgclientSetup(configuration);
+
+  modulixLearningContentReplicationQueue.process(async () => {
+    logger.info('modulixLearningContent.run - Started');
+    await steps.modulixLearningContent(configuration);
+    logger.info('modulixLearningContent.run - Ended');
+    notificationQueue.add({}, { ...jobOptions, attempts: 1 });
+  });
+
+  modulixLearningContentReplicationQueue.add({}, jobOptions);
 
   replicationQueue.process(async function() {
     await steps.backupRestore(configuration);
@@ -51,7 +61,7 @@ async function main() {
 }
 
 async function _setInterruptedJobsAsFailed() {
-  const promises = [replicationQueue, learningContentReplicationQueue, incrementalReplicationQueue, notificationQueue].map(async (queue) => {
+  const promises = [modulixLearningContentReplicationQueue, replicationQueue, learningContentReplicationQueue, incrementalReplicationQueue, notificationQueue].map(async (queue) => {
     const activeJobs = await queue.getActive();
 
     for (const job of activeJobs) {

--- a/src/steps/index.js
+++ b/src/steps/index.js
@@ -1,9 +1,11 @@
+import { run as modulixLearningContent } from './modulix-learning-content/index.js';
 import { run as backupRestore } from './backup-restore/index.js';
 import { run as incremental } from './incremental.js';
 import { run as learningContent } from './learning-content/index.js';
 import { run as notification } from './notification.js';
 
 export {
+  modulixLearningContent,
   backupRestore,
   incremental,
   learningContent,

--- a/src/steps/modulix-learning-content/index.js
+++ b/src/steps/modulix-learning-content/index.js
@@ -1,0 +1,31 @@
+import * as modulixLcmsClient from './lcms-client.js';
+import * as databaseHelper from '../../database-helper.js';
+import { NoLearningContentError } from '../../errors.js';
+import { logger } from '../../logger.js';
+
+const table = {
+  name: 'modules',
+  fields: [
+    { name: 'uuid', type: 'text', extractor: (record) => record['id'] },
+    { name: 'slug', type: 'text' },
+    { name: 'title', type: 'text' },
+  ],
+  indexes: [],
+};
+
+async function run(
+  configuration,
+  dependencies = { databaseHelper: databaseHelper, modulixLcmsClient: modulixLcmsClient },
+) {
+  logger.info(`Modulix replication : tables ${table.name}`);
+  const modules = await dependencies.modulixLcmsClient.getLearningContent();
+
+  if (modules) {
+    await dependencies.databaseHelper.dropTable(table.name, configuration);
+    await dependencies.databaseHelper.createTable(table, configuration);
+    await dependencies.databaseHelper.saveLearningContent(table, modules, configuration);
+  } else {
+    throw new NoLearningContentError();
+  }
+}
+export { run };

--- a/src/steps/modulix-learning-content/lcms-client.js
+++ b/src/steps/modulix-learning-content/lcms-client.js
@@ -1,0 +1,131 @@
+async function getLearningContent() {
+  return Promise.resolve([
+    {
+      id: '5df14039-803b-4db4-9778-67e4b84afbbd',
+      slug: 'adresse-ip-publique-et-vous',
+      title: 'L\'adresse IP publique : ce qu\'elle révèle sur vous !',
+    },
+    {
+      id: '9beb922f-4d8e-495d-9c85-0e7265ca78d6',
+      slug: 'au-dela-des-mots-de-passe',
+      title: 'Au-delà des mots de passe : comment s’authentifier ?',
+    },
+    {
+      id: '6282925d-4775-4bca-b513-4c3009ec5886',
+      slug: 'bac-a-sable',
+      title: 'Bac à sable',
+    },
+    {
+      id: '654c44dc-0560-4acc-9860-4a67c923577f',
+      slug: 'bases-clavier-1',
+      title: 'Les bases du clavier sur ordinateur 1/2',
+    },
+    {
+      id: 'bb0a4ed3-1b49-4782-b867-05ade0868c4f',
+      slug: 'bases-clavier-2',
+      title: 'Les bases du clavier sur ordinateur 2/2',
+    },
+    {
+      id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
+      slug: 'bien-ecrire-son-adresse-mail',
+      title: 'Bien écrire une adresse mail',
+    },
+    {
+      id: '01151659-77c1-41cc-8724-89091357af3d',
+      slug: 'chatgpt-vraiment-neutre',
+      title: 'ChatGPT est-il vraiment neutre ?',
+    },
+    {
+      id: 'd4c4a2b2-0046-471d-ad9c-15f9cfc8f1f6',
+      slug: 'comment-envoyer-un-mail',
+      title: 'Comment envoyer un mail ?',
+    },
+    {
+      id: 'a9e7dda1-fbcc-43a0-a9b4-90056548a4ae',
+      slug: 'controle-parental',
+      title: 'Le contrôle parental',
+    },
+    {
+      id: '1c765240-c790-4f32-8ec0-bc9945bcc5ce',
+      slug: 'decouverte-de-l-ent',
+      title: 'À la découverte de l’ENT',
+    },
+    {
+      id: 'ab82925d-4775-4bca-b513-4c3009ec5886',
+      slug: 'demo-llm',
+      title: 'Démo LLM',
+    },
+    {
+      id: '65b761ab-3ebd-44a9-84b7-8b5e151aee76',
+      slug: 'distinguer-vrai-faux-sur-internet',
+      title: 'Les informations sur internet : distinguer le vrai du faux',
+    },
+    {
+      id: '875df1ff-27c1-4b41-a0a8-5ff46013f35e',
+      slug: 'jeux-video-enfant',
+      title: 'Choisir un jeu vidéo adapté à son enfant',
+    },
+    {
+      id: '8bdec793-7508-41b4-9df2-e1cf96969680',
+      slug: 'mots-de-passe-securises',
+      title: 'Des mots de passe solides',
+    },
+    {
+      id: '12cd102f-9831-4264-8d5e-15a8f177594a',
+      slug: 'ports-connexions-essentiels',
+      title: 'Les ports de connexion d’un ordinateur',
+    },
+    {
+      id: 'a64d1ca8-5222-464a-ae0c-e8bbdf949e18',
+      slug: 'principes-fondateurs-wikipedia',
+      title: 'Les principes fondateurs de Wikipédia',
+    },
+    {
+      id: '68f92c57-9e66-4258-a2f4-b71fad7ab004',
+      slug: 'sources-informations',
+      title: 'Les sources d\'information',
+    },
+    {
+      id: '08ef1a47-b691-4138-b899-39f3512fa152',
+      slug: 'tmp08ef',
+      title: 'Derrière le prompt : comment fonctionnent les IA génératives ?',
+    },
+    {
+      id: '8aa17e6d-3470-479d-838d-ff6923de6686',
+      slug: 'tmp-ia-deepfakes',
+      title: 'Les deepfakes : c’est quoi ?',
+    },
+    {
+      id: '71618929-fcc9-415e-a3f3-9582545d7a78',
+      slug: 'tmp-ia-fonctionnement-debut',
+      title: 'ChatGPT, Gemini, Le Chat : comment font-ils pour répondre à nos demandes ?',
+    },
+    {
+      id: 'cf183961-e85a-421d-a316-05870191ff82',
+      slug: 'tmp-ia-premier-prompt',
+      title: 'Mon premier prompt !',
+    },
+    {
+      id: '7a38c90d-9937-4497-bee3-fe58541af420',
+      slug: 'tmp-prompt-intermediaire',
+      title: 'J\'améliore mon prompt !',
+    },
+    {
+      id: '19468565-a56b-4aa5-9bf0-369e94bc85ea',
+      slug: 'tri-multicritere-tableau',
+      title: 'Trier un tableau selon plusieurs critères',
+    },
+    {
+      id: 'e8cee13e-1d4d-47eb-bd26-d7ea6a10b1e6',
+      slug: 'utiliser-souris-ordinateur-1',
+      title: 'Utiliser une souris d\'ordinateur - 1',
+    },
+    {
+      id: '1f425bc6-7a35-4ceb-9634-a25da1e36233',
+      slug: 'utiliser-souris-ordinateur-2',
+      title: 'Utiliser une souris d\'ordinateur - 2',
+    },
+  ]);
+}
+
+export { getLearningContent };

--- a/test/acceptance/full-dump-replication-test.js
+++ b/test/acceptance/full-dump-replication-test.js
@@ -6,8 +6,10 @@ const pgUrlParser = pgConnectionString.parse;
 import { Database } from '../utils/database.js';
 import { expect, sinon } from '../test-helper.js';
 import { mockLcmsAirtableData } from '../utils/mock-lcms-get-airtable.js';
+import { mockModulixLcmsContent } from '../utils/mock-modulix-lcms-content.js';
 import { run as runBackupRestore } from '../../src/steps/backup-restore/index.js';
 import { run as runLearningContent } from '../../src/steps/learning-content/index.js';
+import { run as runModulixLearningContent } from '../../src/steps/modulix-learning-content/index.js';
 import * as databaseHelper from '../../src/database-helper.js';
 
 async function getCountFromTable({ targetDatabase, tableName }) {
@@ -175,6 +177,25 @@ describe('Acceptance | fullReplicationAndEnrichment', function() {
       // then
       const result = await getCountFromTable({ targetDatabase, tableName: 'learning-content-translations' });
       expect(result).to.equal(fullLearningContent.translations.length);
+    });
+  });
+
+  describe('should import modulix learning content', function() {
+    let fullLearningContent;
+
+    before(async function() {
+      fullLearningContent = mockModulixLcmsContent();
+      const modulixLcmsClient = {
+        getLearningContent: sinon.stub().resolves(fullLearningContent),
+      };
+
+      await runModulixLearningContent(configuration, { modulixLcmsClient: modulixLcmsClient, databaseHelper: databaseHelper });
+    });
+
+    it('should import modules', async function() {
+      // then
+      const result = await getCountFromTable({ targetDatabase, tableName: 'modules' });
+      expect(result).to.equal(fullLearningContent.length);
     });
   });
 

--- a/test/integration/steps/modulix-learning-content/index_test.js
+++ b/test/integration/steps/modulix-learning-content/index_test.js
@@ -1,0 +1,49 @@
+import pgConnectionString from 'pg-connection-string';
+const pgUrlParser = pgConnectionString.parse;
+
+import { Database } from '../../../utils/database.js';
+import { expect, sinon } from '../../../test-helper.js';
+import { mockModulixLcmsContent } from '../../../utils/mock-modulix-lcms-content.js';
+import * as databaseHelper from '../../../../src/database-helper.js';
+
+import { run } from '../../../../src/steps/modulix-learning-content/index.js';
+
+describe('Integration | Steps | modulix-learning-content | index.js', function() {
+  let targetDatabaseConfig;
+  let targetDatabase;
+
+  before(async function() {
+    // CircleCI set up environment variables to access DB, so we need to read them here
+    // eslint-disable-next-line n/no-process-env
+    const DATABASE_URL = process.env.TARGET_DATABASE_URL || 'postgres://pix@localhost:5432/replication_target';
+    const config = pgUrlParser(DATABASE_URL);
+
+    targetDatabaseConfig = {
+      serverUrl: `postgres://${config.user}@${config.host}:${config.port}`,
+      databaseName: config.database,
+      tableName: 'test_table',
+      tableRowCount: 100000,
+    };
+
+    targetDatabase = await Database.create(targetDatabaseConfig);
+  });
+
+  it('should import data', async function() {
+    // given
+    const configuration = {
+      DATABASE_URL: `${targetDatabaseConfig.serverUrl}/${targetDatabaseConfig.databaseName}`,
+    };
+    const fullLearningContent = mockModulixLcmsContent();
+    const modulixLcmsClient = {
+      getLearningContent: sinon.stub(),
+    };
+    modulixLcmsClient.getLearningContent.resolves(fullLearningContent);
+
+    // when
+    await run(configuration, { modulixLcmsClient, databaseHelper });
+
+    // then
+    const moduleRowCount = Number.parseInt(await targetDatabase.runSql('SELECT COUNT(*) FROM modules'));
+    expect(moduleRowCount).to.equal(3);
+  });
+});

--- a/test/unit/steps/modulix-learning-content/index_test.js
+++ b/test/unit/steps/modulix-learning-content/index_test.js
@@ -1,0 +1,48 @@
+import { expect, sinon } from '../../../test-helper.js';
+import * as modulixLearningContent from '../../../../src/steps/modulix-learning-content/index.js';
+import { mockModulixLcmsContent } from '../../../utils/mock-modulix-lcms-content.js';
+
+describe('Unit | Steps | modulix-learning-content | index.js', function() {
+  describe('#run', function() {
+    let databaseHelper;
+    let modulixLcmsClient;
+
+    beforeEach(async function() {
+      const databaseConfig = {};
+      const content = mockModulixLcmsContent();
+      databaseHelper = {
+        dropTable: sinon.stub(),
+        createTable: sinon.stub(),
+        saveLearningContent: sinon.stub(),
+      };
+      databaseHelper.dropTable.resolves();
+      databaseHelper.createTable.resolves();
+      databaseHelper.saveLearningContent.resolves();
+      modulixLcmsClient = {
+        getLearningContent: sinon.stub().resolves(content),
+      };
+
+      await modulixLearningContent.run(databaseConfig, {
+        modulixLcmsClient: modulixLcmsClient,
+        databaseHelper: databaseHelper,
+      });
+    });
+
+    it('should fetch learning-content from LCMS', async function() {
+      expect(modulixLcmsClient.getLearningContent).to.have.been.called;
+    });
+
+    it('should drop existing learning-content tables', async function() {
+      expect(databaseHelper.dropTable.callCount).to.equal(1);
+      expect(databaseHelper.dropTable).to.have.been.calledWith('modules');
+    });
+
+    it('should create learning-content tables', async function() {
+      expect(databaseHelper.createTable.callCount).to.equal(1);
+    });
+
+    it('should insert learning-content data', async function() {
+      expect(databaseHelper.saveLearningContent.callCount).to.equal(1);
+    });
+  });
+});

--- a/test/unit/steps/modulix-learning-content/lcms-client_test.js
+++ b/test/unit/steps/modulix-learning-content/lcms-client_test.js
@@ -1,0 +1,141 @@
+import { expect } from '../../../test-helper.js';
+
+import * as modulixLcmsClient from '../../../../src/steps/modulix-learning-content/lcms-client.js';
+
+describe('Unit | Steps | modulix-learning content | lcms-client.js', function() {
+  describe('#getLearningContent', function() {
+    it('should return static learning content', async function() {
+      // when
+      const modulixLearningContent = await modulixLcmsClient.getLearningContent();
+
+      // then
+      expect(modulixLearningContent).to.deep.equal([
+        {
+          id: '5df14039-803b-4db4-9778-67e4b84afbbd',
+          slug: 'adresse-ip-publique-et-vous',
+          title: 'L\'adresse IP publique : ce qu\'elle révèle sur vous !',
+        },
+        {
+          id: '9beb922f-4d8e-495d-9c85-0e7265ca78d6',
+          slug: 'au-dela-des-mots-de-passe',
+          title: 'Au-delà des mots de passe : comment s’authentifier ?',
+        },
+        {
+          id: '6282925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'bac-a-sable',
+          title: 'Bac à sable',
+        },
+        {
+          id: '654c44dc-0560-4acc-9860-4a67c923577f',
+          slug: 'bases-clavier-1',
+          title: 'Les bases du clavier sur ordinateur 1/2',
+        },
+        {
+          id: 'bb0a4ed3-1b49-4782-b867-05ade0868c4f',
+          slug: 'bases-clavier-2',
+          title: 'Les bases du clavier sur ordinateur 2/2',
+        },
+        {
+          id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
+          slug: 'bien-ecrire-son-adresse-mail',
+          title: 'Bien écrire une adresse mail',
+        },
+        {
+          id: '01151659-77c1-41cc-8724-89091357af3d',
+          slug: 'chatgpt-vraiment-neutre',
+          title: 'ChatGPT est-il vraiment neutre ?',
+        },
+        {
+          id: 'd4c4a2b2-0046-471d-ad9c-15f9cfc8f1f6',
+          slug: 'comment-envoyer-un-mail',
+          title: 'Comment envoyer un mail ?',
+        },
+        {
+          id: 'a9e7dda1-fbcc-43a0-a9b4-90056548a4ae',
+          slug: 'controle-parental',
+          title: 'Le contrôle parental',
+        },
+        {
+          id: '1c765240-c790-4f32-8ec0-bc9945bcc5ce',
+          slug: 'decouverte-de-l-ent',
+          title: 'À la découverte de l’ENT',
+        },
+        {
+          id: 'ab82925d-4775-4bca-b513-4c3009ec5886',
+          slug: 'demo-llm',
+          title: 'Démo LLM',
+        },
+        {
+          id: '65b761ab-3ebd-44a9-84b7-8b5e151aee76',
+          slug: 'distinguer-vrai-faux-sur-internet',
+          title: 'Les informations sur internet : distinguer le vrai du faux',
+        },
+        {
+          id: '875df1ff-27c1-4b41-a0a8-5ff46013f35e',
+          slug: 'jeux-video-enfant',
+          title: 'Choisir un jeu vidéo adapté à son enfant',
+        },
+        {
+          id: '8bdec793-7508-41b4-9df2-e1cf96969680',
+          slug: 'mots-de-passe-securises',
+          title: 'Des mots de passe solides',
+        },
+        {
+          id: '12cd102f-9831-4264-8d5e-15a8f177594a',
+          slug: 'ports-connexions-essentiels',
+          title: 'Les ports de connexion d’un ordinateur',
+        },
+        {
+          id: 'a64d1ca8-5222-464a-ae0c-e8bbdf949e18',
+          slug: 'principes-fondateurs-wikipedia',
+          title: 'Les principes fondateurs de Wikipédia',
+        },
+        {
+          id: '68f92c57-9e66-4258-a2f4-b71fad7ab004',
+          slug: 'sources-informations',
+          title: 'Les sources d\'information',
+        },
+        {
+          id: '08ef1a47-b691-4138-b899-39f3512fa152',
+          slug: 'tmp08ef',
+          title: 'Derrière le prompt : comment fonctionnent les IA génératives ?',
+        },
+        {
+          id: '8aa17e6d-3470-479d-838d-ff6923de6686',
+          slug: 'tmp-ia-deepfakes',
+          title: 'Les deepfakes : c’est quoi ?',
+        },
+        {
+          id: '71618929-fcc9-415e-a3f3-9582545d7a78',
+          slug: 'tmp-ia-fonctionnement-debut',
+          title: 'ChatGPT, Gemini, Le Chat : comment font-ils pour répondre à nos demandes ?',
+        },
+        {
+          id: 'cf183961-e85a-421d-a316-05870191ff82',
+          slug: 'tmp-ia-premier-prompt',
+          title: 'Mon premier prompt !',
+        },
+        {
+          id: '7a38c90d-9937-4497-bee3-fe58541af420',
+          slug: 'tmp-prompt-intermediaire',
+          title: 'J\'améliore mon prompt !',
+        },
+        {
+          id: '19468565-a56b-4aa5-9bf0-369e94bc85ea',
+          slug: 'tri-multicritere-tableau',
+          title: 'Trier un tableau selon plusieurs critères',
+        },
+        {
+          id: 'e8cee13e-1d4d-47eb-bd26-d7ea6a10b1e6',
+          slug: 'utiliser-souris-ordinateur-1',
+          title: 'Utiliser une souris d\'ordinateur - 1',
+        },
+        {
+          id: '1f425bc6-7a35-4ceb-9634-a25da1e36233',
+          slug: 'utiliser-souris-ordinateur-2',
+          title: 'Utiliser une souris d\'ordinateur - 2',
+        },
+      ]);
+    });
+  });
+});

--- a/test/utils/mock-modulix-lcms-content.js
+++ b/test/utils/mock-modulix-lcms-content.js
@@ -1,0 +1,21 @@
+function mockModulixLcmsContent() {
+  return [
+    {
+      id: '6282925d-4775-4bca-b513-4c3009ec5886',
+      slug: 'bac-a-sable',
+      title: 'Bac à sable',
+    },
+    {
+      id: 'f7b3a2e1-0d5c-4c6c-9c4d-1a3d8f7e9f5d',
+      slug: 'bien-ecrire-son-adresse-mail',
+      title: 'Bien écrire une adresse mail',
+    },
+    {
+      id: '01151659-77c1-41cc-8724-89091357af3d',
+      slug: 'chatgpt-vraiment-neutre',
+      title: 'ChatGPT est-il vraiment neutre ?',
+    },
+  ];
+}
+
+export { mockModulixLcmsContent };


### PR DESCRIPTION
## :unicorn: Problème

Les modules sont aujourd'hui en dur dans le code de Pix, ce qui rend impossible leur exploitation dans metabase.

## :robot: Solution

Copier les modules dans une nouvelle table de la base de réplication.

## :rainbow: Remarques

Pour être pragmatique, on commence par mettre en dur la liste des modules (elle n'évolue pas encore très vite). On verra à terme pour mettre en place une mécanique de récupération automatique (qui passe à travers Baleen).

## :100: Pour tester

Lancer la réplication et constater qu'une table `modules` a été créé et remplie.

En local voici les étapes détaillées : 
1. `docker compose down`
2. `docker compose up -d`
3. `npm run local:setup-databases`
4. `node src/main.js`
5. `psql postgres://target_user@localhost/target_database`
6. `SELECT * FROM modules;` => devrait renvoyer des lignes