### PR TITLE
[BUGFIX] Corriger le setup local des BDD

### DIFF
--- a/local-setup/script/create-databases.sql
+++ b/local-setup/script/create-databases.sql
@@ -2,10 +2,12 @@ DROP DATABASE IF EXISTS source_database;
 CREATE DATABASE source_database;
 DROP USER IF EXISTS source_user;
 CREATE USER source_user;
-GRANT ALL PRIVILEGES ON DATABASE source_database TO source_user;
+\c source_database
+GRANT ALL PRIVILEGES ON SCHEMA public TO source_user;
 
 DROP DATABASE IF EXISTS target_database;
 CREATE DATABASE target_database;
 DROP USER IF EXISTS target_user;
 CREATE USER target_user;
-GRANT ALL PRIVILEGES ON DATABASE target_database TO target_user;
+\c target_database
+GRANT ALL PRIVILEGES ON SCHEMA public TO target_user;


### PR DESCRIPTION
## :unicorn: Problème
Avec [PG15](https://www.enterprisedb.com/blog/new-public-schema-permissions-postgresql-15?lang=en), un changement lié aux accès aux schémas a cassé le setup de l'environnement local.

## :robot: Proposition
De nouveau faire en sorte que les écritures soient possibles.

## :rainbow: Remarques
On a pas trouvé de syntaxe pour le faire en one-liner.

## :100: Pour tester
Vérifier que la mise en place de l'environnement local fonctionne sans problème de droits (voir le readme).
