### PR TITLE
[BUGFIX] Répliquer les données des modules périodiquement.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -31,8 +31,6 @@ async function main() {
     notificationQueue.add({}, { ...jobOptions, attempts: 1 });
   });
 
-  modulixLearningContentReplicationQueue.add({}, jobOptions);
-
   replicationQueue.process(async function() {
     await steps.backupRestore(configuration);
     incrementalReplicationQueue.add({}, jobOptions);
@@ -47,7 +45,7 @@ async function main() {
     logger.info('learningContent.run - Started');
     await steps.learningContent(configuration);
     logger.info('learningContent.run - Ended');
-    notificationQueue.add({}, { ...jobOptions, attempts: 1 });
+    modulixLearningContentReplicationQueue.add({}, jobOptions);
   });
 
   notificationQueue.process(async function() {


### PR DESCRIPTION
## :unicorn: Problème

Bien que nous ayons ajouté la réplication des données de Modules, ceux-ci ne sont pas accessibles dans les différents datawarehouse.

## :robot: Solution

On commence par investiguer les logs du datawarehouse après la mise en production censée avoir ajouter les modules.
On constate que des logs de succès sont disponibles, mais uniquement en date du 12 juin, autour de 16h22, ce qui correspond au moment de la mise en production.
Il y a donc un problème sur la répétition du job qui devrait être exécuté toutes les nuits comme les autres données (LearningContent, données de production, etc).
En regardant le code mis en production, on voit que la réplication des données de module est appelé à la racine du `main` mais pas dans l'enchainement de jobs qui est effectué chaque nuit.
Cela signifie donc que la table `modules` a été créée lors du lancement de l'application (lors de la MEP) puis n'a jamais été recréée.
Mais pourquoi a-t-elle été supprimée ?
Cela est due à la variable d'environnement `BACKUP_MODE` qui spécifie les tables qu'il en faut pas supprimer lors de la réplication complète.
Celle-ci ne contenant pas, à juste titre, la table `modules`, la réplication complète commence donc par supprimer cette table.
CQFD

## :rainbow: Remarques

RAS

## :100: Pour tester

Lancer une réplication complète et vérifier que la table `modules` est bien existante et remplie.

