### PR TITLE
[TECH] Ajout des horodatages de changement de statut pour les acquis

### DIFF
--- a/src/steps/learning-content/index.js
+++ b/src/steps/learning-content/index.js
@@ -69,6 +69,10 @@ const tables = [{
     { name: 'learningMoreTutorialIds', type: 'text []', isArray: true },
     { name: 'internationalisation', type: 'text' },
     { name: 'version', type: 'smallint' },
+    { name: 'createdAt', type: 'timestamptz' },
+    { name: 'activatedAt', type: 'timestamptz' },
+    { name: 'archivedAt', type: 'timestamptz' },
+    { name: 'obsoletedAt', type: 'timestamptz' },
   ],
   indexes: ['tubeId'],
 }, {


### PR DESCRIPTION
## :unicorn: Problème
On a ajouté côté pix editor le fait de dater les changements de statuts sur les acquis

## :robot: Solution
Exposer cette donnée dans pix db replication

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
