### PR TITLE
[TECH] Ajouter les addons pour les RA

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -6,6 +6,20 @@
       "value": "true"
     }
   },
+  "addons": [
+    {
+      "plan": "postgresql:postgresql-sandbox",
+      "options": {
+        "version": "16.6"
+      }
+    },
+    {
+      "plan": "redis:redis-sandbox",
+      "options": {
+        "version": "7.2.5"
+      }
+    }
+  ],
   "formation": {
     "web": {
       "amount": 0,


### PR DESCRIPTION
## :unicorn: Problème
Une application template, `pix-datawarehouse-review`, a été créé. Cependant, les RA crées à partir de cette dernière ne contiennent pas les addons redis et postgres

## :robot: Solution
Ajouter les addons dans le fichier scalingo.json

## :100: Pour tester
Vérifier le bon déploiement de la RA.
