### PR TITLE
[TECH] Utiliser la variable d'env $PG_CLIENT_VERSION dans db-schema-exporter.sh

### DIFF
--- a/db-schema-exporter.sh
+++ b/db-schema-exporter.sh
@@ -5,6 +5,8 @@ if [ "${DB_SCHEMA_EXPORTER_ENABLED-x}" = "true" ]
 then
     jq --null-input --compact-output '{level: "info", event: "db-schema-exporter", message: "Data Catalog enrichment starting"}'
 
+    dbclient-fetcher postgresql "$PG_CLIENT_VERSION"
+
     pg_dump "$DATABASE_URL" --schema-only --no-owner --no-privileges --clean --if-exists > schema.sql
 
     psql       \

--- a/src/config/extract-configuration-from-environment.js
+++ b/src/config/extract-configuration-from-environment.js
@@ -33,7 +33,7 @@ const extractConfigurationFromEnvironmentVariable = function() {
   }
 
   return {
-    PG_CLIENT_VERSION: process.env.PG_CLIENT_VERSION || 14,
+    PG_CLIENT_VERSION: process.env.PG_CLIENT_VERSION || 16,
     RETRIES_TIMEOUT_MINUTES: extractInteger(process.env.RETRIES_TIMEOUT_MINUTES) || 180,
     LCMS_API_KEY: process.env.LCMS_API_KEY || '',
     LCMS_API_URL: process.env.LCMS_API_URL || '',


### PR DESCRIPTION
## :unicorn: Problème
Le script `db-schema-exporter.sh` qui permet de dump le schema de la DB pour l'application data-catalog ne fonctionne plus car la version du client PG ne correspond pas à celui de la base (14 au lieu de 16). 

## :robot: Solution
Utiliser la variable d'env $PG_CLIENT_VERSION dans db-schema-exporter.sh