### PR TITLE
[TECH] Supprimer la création d'index sur la colonne `snappedAt` de la table `knowledge-element-snapshots`

### DIFF
--- a/src/steps/backup-restore/enrichment.js
+++ b/src/steps/backup-restore/enrichment.js
@@ -14,12 +14,6 @@ async function createIndexes(configuration) {
       logger.info('CREATE INDEX "knowledge-elements_createdAt_idx" - Ended');
 
     }
-    if (!tablesToNotBeEnriched.includes('knowledge-element-snapshots')) {
-      logger.info('CREATE INDEX "knowledge-element-snapshots_snappedAt_idx" - Started');
-      await client.query('CREATE INDEX "knowledge-element-snapshots_snappedAt_idx" on "knowledge-element-snapshots" (cast("snappedAt" AT TIME ZONE \'UTC+1\' as date) DESC)');
-      logger.info('CREATE INDEX "knowledge-element-snapshots_snappedAt_idx" - Ended');
-
-    }
     if (!tablesToNotBeEnriched.includes('answers')) {
       logger.info('CREATE INDEX "answers_challengeId_idx" - Started');
       await client.query('CREATE INDEX "answers_challengeId_idx" on "answers" ("challengeId")');

--- a/test/acceptance/full-dump-replication-test.js
+++ b/test/acceptance/full-dump-replication-test.js
@@ -211,13 +211,8 @@ describe('Acceptance | fullReplicationAndEnrichment', function() {
       expect(KEIndexCount).to.equal(1);
 
       // then
-      const KESnapshotsIndexCount = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'knowledge-element-snapshots_snappedAt_idx\''));
-      expect(KESnapshotsIndexCount).to.equal(1);
-
-      // then
       const answersIndexCount = parseInt(await targetDatabase.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'answers_challengeId_idx\''));
       expect(answersIndexCount).to.equal(1);
-
     });
   });
 

--- a/test/integration/steps/backup-restore/enrichment_test.js
+++ b/test/integration/steps/backup-restore/enrichment_test.js
@@ -74,10 +74,6 @@ describe('Integration | Steps | Backup restore | enrichment.js', function() {
           expect(KEIndexCount).to.equal(indexCount);
 
           // then
-          const KESnapshotsIndexCount = parseInt(await database.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'knowledge-element-snapshots_snappedAt_idx\''));
-          expect(KESnapshotsIndexCount).to.equal(indexCount);
-
-          // then
           const answersIndexCount = parseInt(await database.runSql('SELECT COUNT(1) FROM pg_indexes ndx WHERE ndx.indexname = \'answers_challengeId_idx\''));
           expect(answersIndexCount).to.equal(indexCount);
 


### PR DESCRIPTION
## :unicorn: Problème
La colonne `snappedAt` de la table `knowledge-element-snapshots` n'existe plus or le code de pix-db-replication cherche à rajouter une index sur cette colonne. 

## :robot: Solution
Supprimer la création d'index sur la colonne `snappedAt` de la table `knowledge-element-snapshots`.