### PR TITLE
[TECH] Ajouter la colonne shortId dans la table Modules (PIX-21107)

### DIFF
--- a/src/steps/modulix-learning-content/index.js
+++ b/src/steps/modulix-learning-content/index.js
@@ -7,6 +7,7 @@ const table = {
   name: 'modules',
   fields: [
     { name: 'uuid', type: 'text', extractor: (record) => record['id'] },
+    { name: 'shortId', type: 'text' },
     { name: 'slug', type: 'text' },
     { name: 'title', type: 'text' },
   ],


### PR DESCRIPTION
## :unicorn: Problème
On a besoin d'afficher le shortId dans la table Modules générée par la réplication.

## :robot: Solution
Ajouter une colonne dans le schéma de la table correspondante.

## :rainbow: Remarques
Les données à insérer ont déjà été mises à jour 😄 

## :100: Pour tester
Ci au vert ✅ 
