### PR TITLE
Sanitize execa output

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -1,16 +1,43 @@
 import { execa } from 'execa';
 
+const transform = function * (line) {
+
+  line = sanitizeCredentials(line);
+
+  yield line;
+
+};
+
+function sanitizeCredentials(text) {
+  const db_credentials_regex = /postgres:\/\/([\w]+:[\w]+)/gi;
+  return text.replace(db_credentials_regex, 'postgres://*:*');
+}
+
 async function execStdOut(cmd, args) {
-  const { stdout } = await execa({ stderr: 'inherit' }) `${cmd} ${args}`;
-  return stdout;
+  try {
+    const { stdout } = await execa({ stdout: transform, stderr: 'inherit' })`${cmd} ${args}`;
+    return stdout;
+  } catch (error) {
+    throw new Error(sanitizeCredentials(error.shortMessage));
+  }
 }
 
-function execShell(cmdline) {
-  return execa({ stdio: 'inherit', shell: true }) `${cmdline}`;
+async function execShell(cmdline) {
+  try {
+    const { stdout } = await execa({ stdout: transform, stderr: 'inherit', shell: true })`${cmdline}`;
+    return stdout;
+  } catch (error) {
+    throw new Error(sanitizeCredentials(error.shortMessage));
+  }
 }
 
-function exec(cmd, args) {
-  return execa({ stdio: 'inherit' }) `${cmd} ${args}`;
+async function exec(cmd, args) {
+  try {
+    const { stdout } = await execa({ stdout: transform, stderr: 'inherit' }) `${cmd} ${args}`;
+    return stdout;
+  } catch (error) {
+    throw new Error(sanitizeCredentials(error.shortMessage));
+  }
 }
 
 export {

--- a/src/exec.js
+++ b/src/exec.js
@@ -24,7 +24,7 @@ async function execStdOut(cmd, args) {
 
 async function execShell(cmdline) {
   try {
-    const { stdout } = await execa({ stdout: transform, stderr: 'inherit', shell: true })`${cmdline}`;
+    const { stdout } = await execa({ stdout: [transform], stderr: 'inherit', shell: true })`${cmdline}`;
     return stdout;
   } catch (error) {
     throw new Error(sanitizeCredentials(error.shortMessage));
@@ -33,7 +33,7 @@ async function execShell(cmdline) {
 
 async function exec(cmd, args) {
   try {
-    const { stdout } = await execa({ stdout: transform, stderr: 'inherit' }) `${cmd} ${args}`;
+    const { stdout } = await execa({ stdout: [transform] }) `${cmd} ${args}`;
     return stdout;
   } catch (error) {
     throw new Error(sanitizeCredentials(error.shortMessage));

--- a/src/exec.js
+++ b/src/exec.js
@@ -15,7 +15,7 @@ function sanitizeCredentials(text) {
 
 async function execStdOut(cmd, args) {
   try {
-    const { stdout } = await execa({ stdout: transform, stderr: 'inherit' })`${cmd} ${args}`;
+    const { stdout } = await execa({ stdout: [transform], stderr: 'inherit' })`${cmd} ${args}`;
     return stdout;
   } catch (error) {
     throw new Error(sanitizeCredentials(error.shortMessage));
@@ -44,4 +44,5 @@ export {
   execStdOut,
   execShell,
   exec,
+  transform,
 };

--- a/src/exec.js
+++ b/src/exec.js
@@ -9,7 +9,7 @@ const transform = function * (line) {
 };
 
 function sanitizeCredentials(text) {
-  const db_credentials_regex = /postgres:\/\/([\w]+:[\w]+)/gi;
+  const db_credentials_regex = /postgres:\/\/([\w-]*:{0,1}[\w-]*)/gi;
   return text.replace(db_credentials_regex, 'postgres://*:*');
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -113,8 +113,8 @@ function _addQueueEventsListeners(queue) {
     .on('completed', function(job) {
       logger.info(`Completed job in ${queue.name}: ${job.id}`);
     })
-    .on('failed', function(job) {
-      logger.error(`Failed job in ${queue.name}: ${job.id} (Number of attempts: ${job.attemptsMade}/${job.opts.attempts})`);
+    .on('failed', function(job, err) {
+      logger.error(`Failed job in ${queue.name}: ${job.id} ${err} (Number of attempts: ${job.attemptsMade}/${job.opts.attempts})`);
     });
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -113,7 +113,7 @@ function _addQueueEventsListeners(queue) {
     .on('completed', function(job) {
       logger.info(`Completed job in ${queue.name}: ${job.id}`);
     })
-    .on('failed', function(job, err) {
+    .on('failed', function(job) {
       logger.error(`Failed job in ${queue.name}: ${job.id} (Number of attempts: ${job.attemptsMade}/${job.opts.attempts})`);
     });
 }

--- a/src/main.js
+++ b/src/main.js
@@ -114,7 +114,7 @@ function _addQueueEventsListeners(queue) {
       logger.info(`Completed job in ${queue.name}: ${job.id}`);
     })
     .on('failed', function(job, err) {
-      logger.error(`Failed job in ${queue.name}: ${job.id} ${err} (Number of attempts: ${job.attemptsMade}/${job.opts.attempts})`);
+      logger.error(`Failed job in ${queue.name}: ${job.id} (Number of attempts: ${job.attemptsMade}/${job.opts.attempts})`);
     });
 }
 

--- a/src/steps/backup-restore/index.js
+++ b/src/steps/backup-restore/index.js
@@ -87,7 +87,7 @@ async function createBackup(configuration, dependencies = { exec: exec }) {
     ...verboseOptions,
     ...excludeOptions,
   ];
-  logger.info(`Backup will be created with command "pg_dump" ${dumpOptions.join(' ')}`);
+  logger.info('Backup will be created');
 
   await dependencies.exec('pg_dump', dumpOptions);
   logger.info('End create Backup');

--- a/src/steps/incremental.js
+++ b/src/steps/incremental.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import { execa } from 'execa';
-import { execStdOut } from '../exec.js';
+import { execStdOut, transform } from '../exec.js';
 import { getTablesWithReplicationModes, REPLICATION_MODE } from '../config/index.js';
 
 import { logger } from '../logger.js';
@@ -65,7 +65,7 @@ async function run(configuration) {
       all: true, // join stdout and stderr
     }) `psql ${copyFromStdInArgs}`;
     const { stdout: copyStdout } = await execa({
-      stdin: 'ignore', stdout: 'pipe', stderr: 'inherit',
+      stdin: 'ignore', stdout: [transform], stderr: 'inherit',
       buffer: false, // disable execa's buffering otherwise it interferes with the transfer
     }) `psql ${copyToStdOutArgs}`
       .pipe(subprocess);

--- a/test/utils/database.js
+++ b/test/utils/database.js
@@ -1,4 +1,4 @@
-import { execa } from 'execa';
+import { execStdOut, exec } from '../../src/exec.js';
 import * as tmp from 'tmp-promise';
 import pgConnectionString from 'pg-connection-string';
 
@@ -25,19 +25,19 @@ export class Database {
 
   async runSql(...sqlCommands) {
     const commands = sqlCommands.map((sqlCommand) => `--command=${sqlCommand}`);
-    const { stdout } = await execa `psql ${this._databaseUrl} --tuples-only --no-align ${commands}`;
+    const { stdout } = await execStdOut('psql', [this._databaseUrl, '--tuples-only', '--no-align', ...commands]);
     return stdout;
   }
 
   async runSqlAsSuperUser(...sqlCommands) {
     const commands = sqlCommands.map((sqlCommand) => `--command=${sqlCommand}`);
-    const { stdout } = await execa `psql ${this._superUserDatabaseUrl} --tuples-only --no-align ${commands}`;
+    const { stdout } = await execStdOut('psql', [this._superUserDatabaseUrl, '--tuples-only', '--no-align', ...commands]);
     return stdout;
   }
 
   async createDatabase() {
     const command = `CREATE DATABASE ${this._databaseName}`;
-    await execa `psql ${this._superUserServerUrl} --echo-all --set ON_ERROR_STOP=on --command ${command}`;
+    await exec('psql', [this._superUserServerUrl, '--echo-all', '--set', 'ON_ERROR_STOP=on', '--command', command]);
 
     await this.runSqlAsSuperUser(
       `CREATE USER ${this._user}`,
@@ -47,12 +47,12 @@ export class Database {
 
   async dropDatabase() {
     const command = `DROP DATABASE IF EXISTS ${this._databaseName}`;
-    await execa `psql ${this._superUserServerUrl} --echo-all --set ON_ERROR_STOP=on --command ${command}`;
+    await exec('psql', [this._superUserServerUrl, '--echo-all', '--set', 'ON_ERROR_STOP=on', '--command', command]);
   }
 
   async createBackup() {
     const path = await tmp.tmpName();
-    await execa({ stdio: 'inherit' }) `pg_dump --format=c --no-owner --no-privileges --file=${path} ${this._superUserDatabaseUrl}`;
+    await exec('pg_dump', ['--format=c', '--no-owner', '--no-privileges', `--file=${path}`, this._superUserDatabaseUrl]);
     return path;
   }
 

--- a/test/utils/database.js
+++ b/test/utils/database.js
@@ -25,13 +25,13 @@ export class Database {
 
   async runSql(...sqlCommands) {
     const commands = sqlCommands.map((sqlCommand) => `--command=${sqlCommand}`);
-    const { stdout } = await execStdOut('psql', [this._databaseUrl, '--tuples-only', '--no-align', ...commands]);
+    const stdout = await execStdOut('psql', [this._databaseUrl, '--tuples-only', '--no-align', ...commands]);
     return stdout;
   }
 
   async runSqlAsSuperUser(...sqlCommands) {
     const commands = sqlCommands.map((sqlCommand) => `--command=${sqlCommand}`);
-    const { stdout } = await execStdOut('psql', [this._superUserDatabaseUrl, '--tuples-only', '--no-align', ...commands]);
+    const stdout = await exec('psql', [this._superUserDatabaseUrl, '--tuples-only', '--no-align', ...commands]);
     return stdout;
   }
 


### PR DESCRIPTION
## :unicorn: Problème

Les scripts d’exécutions log les infos de connexion en cas d'erreur.
 
## :robot: Solution

Utilisation d'une fonction de transformation pour traiter la sortie execa.

## :rainbow: Remarques

URL postgres testées

```text
postgres://postgres@localhost:5432/replication_target
postgres://_post_gres:pass_word_@localhost:5432/replication_target
postgres://_post-gres:pass_wo-rd_@localhost:5432/replication_target
postgres://post_-gres@localhost:5432/replication_target
``` 

## :100: Pour tester
