### PR TITLE
[FEATURE] Ajout d'un timeout sur les opérations drop (PIX-21346)

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,16 +299,12 @@ node -e "require('./src/steps/learning-content').run(require ('./src/config/extr
 
 #### RA Scalingo
 
-- Faire un backup des données d'une application Scalingo hors `osc-secnum-fr1`
-pour éviter les considérations de sécurité des données
-
-- Vérifier les données présentes dans la BDD à exporter (exemple pour les données d'une review app)
-
-``` bash
-scalingo -a pix-api-review-prxxx pgsql-console
-```
-
-- Lancer un backup (ou ne rien faire, le dernier est utilisé par défaut)
+- Par défaut :
+  - la review app réplique les données de la base de données de l'environnement d'intégration
+  Pix. Vous pouvez changer la source de données en modifiant la variable d'environnement `SOURCE_DATABASE_URL`
+  - aucune table n'est configurée en incremental (la base destination étant vide au départ). Après une 1ère réplication
+  complète, il est possible d'ajouter une configuration incrémentale sur certaines tables en modifiant la variable 
+  d'environnement `BACKUP_MODE` (ex : `"answers":"incremental"` et `"knowledge-elements":"incremental"`)
 
 - Déterminer le nom de l'application de RA Scalingo de db-replication
 
@@ -316,7 +312,7 @@ scalingo -a pix-api-review-prxxx pgsql-console
 NOM_APPLICATION=pix-datawarehouse-pr<NUMERO-PR>
 ```
 
-- Lancer le process de création et d'import du backup sur cette RA
+- Lancer le process de réplication sur la RA
 
 ``` bash
 scalingo run --region osc-fr1 --app $NOM_APPLICATION npm run restart:full-replication

--- a/sample.env
+++ b/sample.env
@@ -88,6 +88,13 @@ MAX_RETRY_COUNT=
 # default: 4
 PG_RESTORE_JOBS=
 
+# Délai avant timeout des commandes de drop (tables, séquences, vues...) en millisecondes.
+#
+# presence: optional
+# type: Number
+# default: 300000 (5mn)
+DROP_TIMEOUT_MS=
+
 # Restaurer ou non les contraintes de clés étrangères. Si non renseignée, les
 # contraintes de clés étrangères ne sont pas restaurées. Si "true", les
 # contraintes de clés étrangères sont restaurées.

--- a/sample.env
+++ b/sample.env
@@ -73,13 +73,12 @@ LCMS_API_KEY=e5d7b101-d0bd-4a3b-86c9-61edd5d39e8d
 # sample: SCHEDULE=10 5 * * *
 SCHEDULE=
 
-# Cette variable est utilisée pour indiquer le nombre maximum de tentative de
-# rejeux
+# Cette variable est utilisée pour indiquer le nombre maximum de tentatives (initiale + rejeux)
 #
-# presence: required
+# presence: optional
 # type: Number
 # default: 10
-MAX_RETRY_COUNT=
+MAX_ATTEMPT_NB=
 
 # Nombre de processus à utiliser pour restaurer le backup
 #

--- a/sample.env
+++ b/sample.env
@@ -41,13 +41,6 @@ NODE_ENV=
 # default: 12
 PG_CLIENT_VERSION=
 
-# Durée maximum autorisée pour la restauration (en secondes)
-#
-# presence: required
-# type: Number
-# default: 180
-RETRIES_TIMEOUT_MINUTES=
-
 # Learning content API URL.
 #
 # presence: required

--- a/src/config/extract-configuration-from-environment.js
+++ b/src/config/extract-configuration-from-environment.js
@@ -41,6 +41,7 @@ const extractConfigurationFromEnvironmentVariable = function() {
     MAX_RETRY_COUNT: extractInteger(process.env.MAX_RETRY_COUNT) || 10,
     MIN_TIMEOUT: extractInteger(process.env.MIN_TIMEOUT) || 900000, // 15 min
     MAX_TIMEOUT: extractInteger(process.env.MAX_TIMEOUT) || 900000, // 15 min
+    DROP_TIMEOUT_MS: extractInteger(process.env.DROP_TIMEOUT_MS) || 5 * 60 * 1000, // timeout for drop commands - 5min by default
     PG_RESTORE_JOBS: extractInteger(process.env.PG_RESTORE_JOBS) || 4,
     RESTORE_FK_CONSTRAINTS: process.env.RESTORE_FK_CONSTRAINTS || 'true',
     BACKUP_MODE,

--- a/src/config/extract-configuration-from-environment.js
+++ b/src/config/extract-configuration-from-environment.js
@@ -34,13 +34,10 @@ const extractConfigurationFromEnvironmentVariable = function() {
 
   return {
     PG_CLIENT_VERSION: process.env.PG_CLIENT_VERSION || 16,
-    RETRIES_TIMEOUT_MINUTES: extractInteger(process.env.RETRIES_TIMEOUT_MINUTES) || 180,
     LCMS_API_KEY: process.env.LCMS_API_KEY || '',
     LCMS_API_URL: process.env.LCMS_API_URL || '',
     SCHEDULE: process.env.SCHEDULE || '10 5 * * *',
     MAX_ATTEMPT_NB: extractInteger(process.env.MAX_ATTEMPT_NB) || 10,
-    MIN_TIMEOUT: extractInteger(process.env.MIN_TIMEOUT) || 900000, // 15 min
-    MAX_TIMEOUT: extractInteger(process.env.MAX_TIMEOUT) || 900000, // 15 min
     DROP_TIMEOUT_MS: extractInteger(process.env.DROP_TIMEOUT_MS) || 5 * 60 * 1000, // timeout for drop commands - 5min by default
     PG_RESTORE_JOBS: extractInteger(process.env.PG_RESTORE_JOBS) || 4,
     RESTORE_FK_CONSTRAINTS: process.env.RESTORE_FK_CONSTRAINTS || 'true',

--- a/src/config/extract-configuration-from-environment.js
+++ b/src/config/extract-configuration-from-environment.js
@@ -38,7 +38,7 @@ const extractConfigurationFromEnvironmentVariable = function() {
     LCMS_API_KEY: process.env.LCMS_API_KEY || '',
     LCMS_API_URL: process.env.LCMS_API_URL || '',
     SCHEDULE: process.env.SCHEDULE || '10 5 * * *',
-    MAX_RETRY_COUNT: extractInteger(process.env.MAX_RETRY_COUNT) || 10,
+    MAX_ATTEMPT_NB: extractInteger(process.env.MAX_ATTEMPT_NB) || 10,
     MIN_TIMEOUT: extractInteger(process.env.MIN_TIMEOUT) || 900000, // 15 min
     MAX_TIMEOUT: extractInteger(process.env.MAX_TIMEOUT) || 900000, // 15 min
     DROP_TIMEOUT_MS: extractInteger(process.env.DROP_TIMEOUT_MS) || 5 * 60 * 1000, // timeout for drop commands - 5min by default

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -5,7 +5,7 @@ const configuration = extractConfigurationFromEnvironment();
 const parisTimezone = 'Europe/Paris';
 
 const jobOptions = {
-  attempts: configuration.MAX_RETRY_COUNT,
+  attempts: configuration.MAX_ATTEMPT_NB,
   backoff: { type: 'exponential', delay: configuration.EXPONENTIAL_RETRY_DELAY },
 };
 

--- a/src/exec.js
+++ b/src/exec.js
@@ -31,11 +31,14 @@ async function execShell(cmdline) {
   }
 }
 
-async function exec(cmd, args) {
+async function exec(cmd, args, timeout) {
   try {
-    const { stdout } = await execa({ stdout: [transform] }) `${cmd} ${args}`;
+    const { stdout } = await execa({ stdout: [transform], timeout }) `${cmd} ${args}`;
     return stdout;
   } catch (error) {
+    if (error.timedOut) {
+      throw new Error(sanitizeCredentials(`Command timed out after ${timeout / 1000}s: ${cmd} ${args}`));
+    }
     throw new Error(sanitizeCredentials(error.shortMessage));
   }
 }

--- a/src/steps/backup-restore/index.js
+++ b/src/steps/backup-restore/index.js
@@ -14,21 +14,21 @@ const RESTORE_LIST_FILENAME = 'restore.list';
 async function dropCurrentObjects(configuration) {
   const tablesToKeep = getTablesWithReplicationModes(configuration, [REPLICATION_MODE.INCREMENTAL, REPLICATION_MODE.TO_EXCLUDE]);
   if (tablesToKeep.length > 0) {
-    return dropCurrentObjectsExceptTables(configuration.DATABASE_URL, tablesToKeep);
+    return dropCurrentObjectsExceptTables(configuration.DATABASE_URL, tablesToKeep, configuration.DROP_TIMEOUT_MS);
   }
   else return exec('psql', [configuration.DATABASE_URL, ' --echo-all', '--set', 'ON_ERROR_STOP=on', '--command', 'DROP OWNED BY CURRENT_USER CASCADE']);
 }
 
-async function dropCurrentObjectsExceptTables(databaseUrl, tableNames) {
+async function dropCurrentObjectsExceptTables(databaseUrl, tableNames, timeout) {
   const tableNamesForQuery = tableNames.map((tableName) => tableName.includes('*') ? `(${tableName.replace('*', '.*')})` : `(${tableName})`).join('|');
   const dropTableQuery = await execStdOut('psql', [databaseUrl, '--tuples-only', '--command', `select string_agg('drop table "' || tablename || '" CASCADE', '; ') from pg_tables where schemaname = 'public' and tablename !~ '^(${tableNamesForQuery})$';`]);
-  await exec('psql', [databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropTableQuery]);
+  await exec('psql', [databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropTableQuery], timeout);
   const dropEnumQuery = await execStdOut('psql', [databaseUrl, '--tuples-only', '--command', 'select string_agg(\'drop type "\' || typname || \'"\', \'; \') from (select distinct t.typname from pg_type t join pg_enum e on t.oid = e.enumtypid join pg_namespace as n on t.typnamespace = n.oid where n.nspname = \'public\') as typenames;']);
-  await exec('psql', [databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropEnumQuery]);
+  await exec('psql', [databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropEnumQuery], timeout);
   const dropViews = await execStdOut('psql', [databaseUrl, '--tuples-only', '--command', 'select string_agg(\'drop view "\' || viewname || \'"\', \'; \') FROM pg_views where viewowner=current_user']);
-  await exec('psql', [databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropViews]);
+  await exec('psql', [databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropViews], timeout);
   const dropFunction = await execStdOut('psql', [databaseUrl, '--tuples-only', '--command', 'select string_agg(\'drop function "\' || proname || \'"\', \'; \') FROM pg_proc pp INNER JOIN pg_roles pr ON pp.proowner = pr.oid WHERE pr.rolname = current_user ']);
-  return exec('psql', [databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropFunction]);
+  return exec('psql', [databaseUrl, '--set', 'ON_ERROR_STOP=on', '--echo-all', '--command', dropFunction], timeout);
 }
 
 async function writeListFileForReplication({ backupFile, configuration }) {


### PR DESCRIPTION
## :unicorn: Problème
Quand les objets à répliquer sont utilisés par une requête bloquée sur la base destination, l'opération de drop ne peut pas aboutir. Or, aucun timeout n'est configuré sur ces opérations et le traitement n'échoue qu'au bout de 24h.

## :robot: Solution
Ajouter un timeout de 5mn par défault sur les requêtes de drop qui ne sont censées durer que quelques secondes. Le traitement ne sera alors plus bloqué en cas d'impossibilité de suppression des objets.
Le timeout peut être configuré à l'aide de la variable d'environnement `DROP_TIMEOUT_MS`.

## :rainbow: Remarques
* La variable d'environnement gérant le nombre de tentatives sur le traitement a été renommée pour bien indiquer qu'il ne s'agit pas uniquement du nombre de nouvelles tentatives mais bien du nombre global de tentatives. Cette variable d'environnement ayant été passée à 1 sur l'ensemble des plateformes, il n'y aura plus de nouvelle tentative en cas d'échec sur la réplication. Cette configuration pourra être revue en cas de besoin.
* 3 variables d'environnement inutilisées ont été supprimées : `RETRIES_TIMEOUT_MINUTES`, `MIN_TIMEOUT` et `MAX_TIMEOUT`

## :100: Pour tester

**1. Réplication réussie**

- Supprimer la variable d'environnement DROP_TIMEOUT_MS si elle existe pour utiliser la valeur par défaut de 5 minutes.
- Lancer la réplication : 
```
scalingo run --region osc-fr1 --app pix-datawarehouse-review-pr354 npm run restart:full-replication
```
--> Celle-ci aboutit sans erreur. 

**2. Réplication en échec suite à un timeout**

- Positionner la variable d'environnement DROP_TIMEOUT_MS à 60000 pour avoir un timeout d'une minute. 

- Bloquer un table à répliquer (`users` par exemple) à l'aide d'une transaction contenant un lock et un sleep : 
```
BEGIN;

-- Ce verrou empêche toute modification de structure (comme DROP)
LOCK TABLE users IN SHARE UPDATE EXCLUSIVE MODE;

-- On maintient le verrou pendant 10 minutes
SELECT pg_sleep(600);

COMMIT;

```
- Lancer une réplication.
--> Celle-ci doit échouer avec un message indiquant que le drop à échoué sur un timeout.

`Failed job in Replication queue: 104 Error: Command timed out after 60s: psql (Number of attempts: 1/1)`
