### PR TITLE
[FEATURE] Suppression de la colonne "champ contextualisé" (PIX-22421)

### DIFF
--- a/src/steps/learning-content/index.js
+++ b/src/steps/learning-content/index.js
@@ -122,7 +122,6 @@ const tables = [{
     { name: 'solution', type: 'text' },
     { name: 'pedagogy', type: 'text' },
     { name: 'shuffled', type: 'boolean', extractor: (record) => !!record['shuffled'] },
-    { name: 'contextualizedFields', type: 'text []', isArray: true },
     { name: 'urlsToConsult', type: 'text []', isArray: true },
     { name: 'format', type: 'text' },
   ],


### PR DESCRIPTION
## :unicorn: Problème

On cherche à supprimer "champ contextualisé" coté pix-editor.

## :robot: Solution

Etre ISO et le supprimé ici aussi.

## :rainbow: Remarques

RAS

## :100: Pour tester
CI ok !