### PR TITLE
[FEATURE] Ajout de deux champs au niveau des épreuves. (PIX-22424)

### DIFF
--- a/src/steps/learning-content/index.js
+++ b/src/steps/learning-content/index.js
@@ -124,6 +124,8 @@ const tables = [{
     { name: 'shuffled', type: 'boolean', extractor: (record) => !!record['shuffled'] },
     { name: 'urlsToConsult', type: 'text []', isArray: true },
     { name: 'format', type: 'text' },
+    { name: 'assessmentMaintenanceTags', type: 'text []', isArray: true },
+    { name: 'translationMaintenanceTags', type: 'text []', isArray: true },
   ],
   indexes: ['firstSkillId'],
 }, {

--- a/test/utils/mock-learning-content.js
+++ b/test/utils/mock-learning-content.js
@@ -644,6 +644,8 @@ export function mockLearningContentData() {
         'toRephrase': true,
         'isAwarenessChallenge': true,
         'isQualityOk': true,
+        'assessmentMaintenanceTags': ['Fichier simple à traduire'],
+        'translationMaintenanceTags': ['question outil'],
       },
       {
         'airtableId': 'rec2ZkgH8IDwAoeA6',
@@ -677,6 +679,8 @@ export function mockLearningContentData() {
         'toRephrase': false,
         'isAwarenessChallenge': false,
         'isQualityOk': false,
+        'assessmentMaintenanceTags': ['Fichier simple à traduire'],
+        'translationMaintenanceTags': ['question outil'],
       },
       {
         'airtableId': 'rec4RHc2v3am5VJvY',
@@ -712,6 +716,8 @@ export function mockLearningContentData() {
         'toRephrase': true,
         'isAwarenessChallenge': false,
         'isQualityOk': true,
+        'assessmentMaintenanceTags': ['Fichier simple à traduire'],
+        'translationMaintenanceTags': ['question outil'],
       },
       {
         'airtableId': 'recc3QU4nKAk4byGv',
@@ -745,6 +751,8 @@ export function mockLearningContentData() {
         'toRephrase': false,
         'isAwarenessChallenge': true,
         'isQualityOk': false,
+        'assessmentMaintenanceTags': ['Fichier simple à traduire'],
+        'translationMaintenanceTags': ['question outil'],
       },
       {
         'airtableId': 'recc5bnzo6lvwyIgD',
@@ -779,6 +787,8 @@ export function mockLearningContentData() {
         'toRephrase': false,
         'isAwarenessChallenge': true,
         'isQualityOk': false,
+        'assessmentMaintenanceTags': [],
+        'translationMaintenanceTags': [],
       },
       {
         'airtableId': 'receffAhZMTJDx5Zv',
@@ -812,6 +822,8 @@ export function mockLearningContentData() {
         'toRephrase': false,
         'isAwarenessChallenge': false,
         'isQualityOk': false,
+        'assessmentMaintenanceTags': ['Fichier simple à traduire'],
+        'translationMaintenanceTags': ['question outil'],
       },
       {
         'airtableId': 'receWJAbh7Tib2uHb',
@@ -845,6 +857,8 @@ export function mockLearningContentData() {
         'toRephrase': false,
         'isAwarenessChallenge': false,
         'isQualityOk': false,
+        'assessmentMaintenanceTags': ['Fichier simple à traduire'],
+        'translationMaintenanceTags': ['question outil'],
       },
     ],
     'attachments': [


### PR DESCRIPTION
## :unicorn: Problème
Nous avons créé deux nouveaux champs au niveau des épreuves du référentiel que nous voulons rendre accessible depuis metabase 

## :robot: Solution
Ajouter ces champs lors de la réplication

## :rainbow: Remarques
Attendre la release de pix-editor

## :100: Pour tester
tests au vert
