### PR TITLE
[FEATURE] Utilisation de la configuration MAX_ATTEMPT_NB pour l'étape de notification

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -37,7 +37,7 @@ async function main() {
     logger.info('learningContent.run - Started');
     await steps.learningContent(configuration);
     logger.info('learningContent.run - Ended');
-    notificationQueue.add({}, { ...jobOptions, attempts: 1 });
+    notificationQueue.add({}, jobOptions);
   });
 
   notificationQueue.process(async function() {


### PR DESCRIPTION
## :unicorn: Problème

La notification ne bénéficie pas du système de retry en cas d'échec. Nous n'avons pas d'historique sur le sujet, mais cette exception provient probablement du fait que l'étape de notification ne pouvait pas être relancée en cas d'échec (plusieurs opérations non idempodentes par exemple).

L'étape de notification ne consiste plus qu'à prévenir Airflow. Si elle échoue, elle peut bien être relancée.

## :robot: Solution

Supprimer l'exception qui fait que l'étape de notification ne bénéficie pas du fonctionnement standard de retries.

## :100: Pour tester

Configurer dans les variables d'environnement : 
* la notification pour réaliser une opération qui va échouer.
* le MAX_ATTEMPT_NB à une valeur strictement supérieure à 1 (2 par exemple)

Lancer une réplication de test. 
-> La notification est lancée autant de fois que la configuration le prévoie.
