### PR TITLE
[TECH] Utiliser la nouvelle authentification de Pix Editor (PIX-23703)

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -55,6 +55,13 @@ LCMS_API_URL=https://lcms.minimal.pix.fr/api
 # default: none
 LCMS_API_KEY=e5d7b101-d0bd-4a3b-86c9-61edd5d39e8d
 
+# Base64(username:password) to fetch learning content management system.
+#
+# presence: required
+# type: String
+# default: none
+LCMS_OAUTH2_PROXY_BASIC_TOKEN=bWluaW1hbDpwaXgxMjM
+
 # Une chaîne au format `cron` (interprétée par
 # https://www.npmjs.com/package/node-cron) qui spécifie la fréquence à
 # laquelle l'opération de réplication doit être exécutée. Exemple :

--- a/src/config/extract-configuration-from-environment.js
+++ b/src/config/extract-configuration-from-environment.js
@@ -36,6 +36,7 @@ const extractConfigurationFromEnvironmentVariable = function() {
     PG_CLIENT_VERSION: process.env.PG_CLIENT_VERSION || 16,
     LCMS_API_KEY: process.env.LCMS_API_KEY || '',
     LCMS_API_URL: process.env.LCMS_API_URL || '',
+    LCMS_OAUTH2_PROXY_BASIC_TOKEN: process.env.LCMS_OAUTH2_PROXY_BASIC_TOKEN || '',
     SCHEDULE: process.env.SCHEDULE || '10 5 * * *',
     MAX_ATTEMPT_NB: extractInteger(process.env.MAX_ATTEMPT_NB) || 10,
     DROP_TIMEOUT_MS: extractInteger(process.env.DROP_TIMEOUT_MS) || 5 * 60 * 1000, // timeout for drop commands - 5min by default

--- a/src/steps/learning-content/lcms-client.js
+++ b/src/steps/learning-content/lcms-client.js
@@ -8,7 +8,7 @@ export async function* streamLearningContent(configuration) {
   try {
     const response = await fetch(url, {
       headers: {
-        'Authorization': `Bearer ${configuration.LCMS_API_KEY}`,
+        'X-API-Key': configuration.LCMS_API_KEY,
         'client': process.env.APP ?? 'pix-db-replication', // eslint-disable-line n/no-process-env
       },
     });

--- a/src/steps/learning-content/lcms-client.js
+++ b/src/steps/learning-content/lcms-client.js
@@ -9,6 +9,7 @@ export async function* streamLearningContent(configuration) {
     const response = await fetch(url, {
       headers: {
         'X-API-Key': configuration.LCMS_API_KEY,
+        'Authorization': `Basic ${configuration.LCMS_OAUTH2_PROXY_BASIC_TOKEN}`,
         'client': process.env.APP ?? 'pix-db-replication', // eslint-disable-line n/no-process-env
       },
     });

--- a/test/integration/steps/learning-content/lcms-client_test.js
+++ b/test/integration/steps/learning-content/lcms-client_test.js
@@ -9,9 +9,11 @@ describe('Integration | Steps | learning-content | lcms-client.js', function() {
     beforeEach(function() {
       const lcmsApiUrl = 'https://lcms-test.pix.fr/api';
       const lcmsApiKey = 'abcd';
+      const lcmsOauth2ProxyBasicToken = 'abcd=';
       configuration = {
         LCMS_API_URL: lcmsApiUrl,
         LCMS_API_KEY: lcmsApiKey,
+        LCMS_OAUTH2_PROXY_BASIC_TOKEN: lcmsOauth2ProxyBasicToken,
       };
       nock.disableNetConnect();
     });
@@ -25,6 +27,7 @@ describe('Integration | Steps | learning-content | lcms-client.js', function() {
       nock('https://lcms-test.pix.fr', {
         reqheaders: {
           'X-Api-Key': 'abcd',
+          'Authorization': 'Basic abcd=',
           client: 'pix-db-replication',
         } })
         .get('/api/replication-stream')

--- a/test/integration/steps/learning-content/lcms-client_test.js
+++ b/test/integration/steps/learning-content/lcms-client_test.js
@@ -24,7 +24,7 @@ describe('Integration | Steps | learning-content | lcms-client.js', function() {
       // given
       nock('https://lcms-test.pix.fr', {
         reqheaders: {
-          authorization: 'Bearer abcd',
+          'X-Api-Key': 'abcd',
           client: 'pix-db-replication',
         } })
         .get('/api/replication-stream')


### PR DESCRIPTION
## :unicorn: Problème

Suite à l'[incident Pudding](https://1024pix.atlassian.net/browse/PIX-23698), on ajoute l'OAuth Proxy sur Pix Editor.

Comme l'en-tête Authorization: Bearer est déjà utilisé sur Pix Editor, on modifie l'en-tête utilisé pour l'authentification.

## :robot: Solution

* Modification de l'en-tête utilisé pour se connecter au LCMS, pour utiliser `X-API-Key`
* Ajout d'un en-tête `Authorization: Basic`

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
