### PR TITLE
[BUGFIX] Échapper les caractères spéciaux lors de l'insertion de listes lors de la réplication du LCMS (PIX-23678)

### DIFF
--- a/src/steps/learning-content/learning-content-helper.js
+++ b/src/steps/learning-content/learning-content-helper.js
@@ -4,7 +4,12 @@ function prepareLearningContentValueBeforeInsertion(learningContentItem, fieldSt
   if (!Array.isArray(value)) {
     return value;
   }
-  return fieldStructure.isArray ? `{${value.join(',')}}` : value[0];
+  return fieldStructure.isArray ? `{${value.map(escapeSpecialCharacters).join(',')}}` : value[0];
+}
+
+function escapeSpecialCharacters(value) {
+  if (!value) return value;
+  return '"' + value.replaceAll('\\', '\\\\').replaceAll('"', '\\"') + '"';
 }
 
 export {

--- a/test/integration/steps/learning-content/index_test.js
+++ b/test/integration/steps/learning-content/index_test.js
@@ -24,7 +24,9 @@ describe('Integration | Steps | learning-content | index.js', function() {
       tableName: 'test_table',
       tableRowCount: 100000,
     };
+  });
 
+  beforeEach(async function() {
     targetDatabase = await Database.create(targetDatabaseConfig);
   });
 
@@ -44,5 +46,64 @@ describe('Integration | Steps | learning-content | index.js', function() {
     // then
     const competenceRowCount = parseInt(await targetDatabase.runSql('SELECT COUNT(*) FROM competences'));
     expect(competenceRowCount).to.equal(6);
+  });
+
+  describe('input data edge cases', function() {
+    it('should import data with string array that has special characters inside each element', async function() {
+      // given
+      const configuration = {
+        DATABASE_URL: `${targetDatabaseConfig.serverUrl}/${targetDatabaseConfig.databaseName}`,
+      };
+      const lcmsClient = {
+        streamLearningContent: sinon.stub(),
+      };
+
+      function mockLearningContentWithWeirdChallenge() {
+        return {
+          challenges: [
+            {
+              'airtableId': 'rec0hSrPM5bHqMP8T',
+              'alternativeInstruction': '',
+              'autoReply': true,
+              'competenceId': 'recKxnZJh5dyRCQQn',
+              'embedHeight': 500,
+              'format': 'mots',
+              'focusable': true,
+              'id': 'rec0hSrPM5bHqMP8T',
+              'instruction': 'Quelles sont les dates des deux guerres mondiales ?',
+              'locales': [
+                'fr',
+                'fr-fr',
+              ],
+              'preview': 'http://staging.pix.fr/challenges/rec0hSrPM5bHqMP8T/preview',
+              'proposals': 'Dates :\n.${date1}\n.${date2}',
+              'skillId': 'recWAozQQmkLzs15C',
+              'solution': 'groupe1:\n- 14 18\n- 1914 1918\ngroupe2:\n- 39 45\n- 1939 1945',
+              'status': 'validé',
+              't1Status': false,
+              't2Status': false,
+              't3Status': false,
+              'deafAndHardOfHearing': 'OK',
+              'requireGafamWebsiteAccess': true,
+              'isIncompatibleIpadCertif': true,
+              'toRephrase': true,
+              'isAwarenessChallenge': true,
+              'isQualityOk': true,
+              'assessmentMaintenanceTags': ['MOT, AUTRE MOT', 'ENSUITRE "TUT" \\n'],
+              'translationMaintenanceTags': ['question outil'],
+            },
+          ],
+        };
+      }
+
+      lcmsClient.streamLearningContent.returns(mockLearningContentStream(mockLearningContentWithWeirdChallenge));
+
+      // when
+      await run(configuration, { lcmsClient, databaseHelper });
+
+      // then
+      const challenges = await targetDatabase.runSql('SELECT "assessmentMaintenanceTags" FROM challenges');
+      expect(challenges).to.equal('{"MOT, AUTRE MOT","ENSUITRE \\"TUT\\" \\\\n"}');
+    });
   });
 });

--- a/test/unit/steps/learning-content/learning-content-helper_test.js
+++ b/test/unit/steps/learning-content/learning-content-helper_test.js
@@ -61,7 +61,7 @@ describe('Unit | Steps | learning content | learning-content-helper.js', functio
       const value = learningContentHelper.prepareLearningContentValueBeforeInsertion(learningContentItem, fieldStructure);
 
       // then
-      expect(value).to.deep.equal('{recH9MjIzN54zXlwr,recxlJqKdbWHHFZMQ,recKxnZJh5dyRCQQn,recZ1Gm4rud4zLhbF}');
+      expect(value).to.deep.equal('{"recH9MjIzN54zXlwr","recxlJqKdbWHHFZMQ","recKxnZJh5dyRCQQn","recZ1Gm4rud4zLhbF"}');
     });
 
     it('should return formatted array from extractor', function() {
@@ -72,7 +72,7 @@ describe('Unit | Steps | learning content | learning-content-helper.js', functio
       const value = learningContentHelper.prepareLearningContentValueBeforeInsertion(learningContentItem, fieldStructure);
 
       // then
-      expect(value).to.deep.equal('{recH9MjIzN54zXlwr,recxlJqKdbWHHFZMQ,recKxnZJh5dyRCQQn,recZ1Gm4rud4zLhbF}');
+      expect(value).to.deep.equal('{"recH9MjIzN54zXlwr","recxlJqKdbWHHFZMQ","recKxnZJh5dyRCQQn","recZ1Gm4rud4zLhbF"}');
     });
   });
 

--- a/test/utils/mock-learning-content.js
+++ b/test/utils/mock-learning-content.js
@@ -966,8 +966,8 @@ export function mockLearningContentData() {
   };
 }
 
-export async function* mockLearningContentStream() {
-  for (const [type, values] of Object.entries(mockLearningContentData())) {
+export async function* mockLearningContentStream(mockLearningContentDataFunc = mockLearningContentData) {
+  for (const [type, values] of Object.entries(mockLearningContentDataFunc())) {
     for (const value of values) {
       yield { type, value };
     }


### PR DESCRIPTION
## :unicorn: Problème
Il y a un problème quand le tag "Règles, législation ou connaissance" (`challenges.assessmentMaintenanceTags`) est répliqué. À cause de la virgule, il y a deux tags en base au lieu d'un seul. 

## :robot: Solution
Échapper les caractères spéciaux lors de l'insertion de listes.

## :rainbow: Remarques
Si on utilisait `knex` sur ce dépôt, le problème n'aurait jamais eu lieu.

## :100: Pour tester
✅ CI Verte, on a ajouté un test 😃
Un test fonctionnel a été réalisé avec les données de réplication du LCMS d'intégration.
